### PR TITLE
[refactor] CI 스크립트 name 변경 및 paths, working-directory 상대 경로(./) 삭제

### DIFF
--- a/.github/workflows/common_build_test.yml
+++ b/.github/workflows/common_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Common - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './common/**'
+      - 'common/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./company
+        working-directory: common
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/company_build_test.yml
+++ b/.github/workflows/company_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Company - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './company/**'
+      - 'company/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./company
+        working-directory: company
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/config_build_test.yml
+++ b/.github/workflows/config_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Config - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './config/**'
+      - 'config/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./config
+        working-directory: config
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/delivery_build_test.yml
+++ b/.github/workflows/delivery_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Delivery - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './delivery/**'
+      - 'delivery/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./delivery
+        working-directory: delivery
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/eurekaServer_build_test.yml
+++ b/.github/workflows/eurekaServer_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: EurekaServer - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './eurekaServer/**'
+      - 'eurekaServer/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./eurekaServer
+        working-directory: eurekaServer
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/gateWay_build_test.yml
+++ b/.github/workflows/gateWay_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: GateWay - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './gateWay/**'
+      - 'gateWay/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./gateWay
+        working-directory: gateWay
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/hub_build_test.yml
+++ b/.github/workflows/hub_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Hub - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './hub/**'
+      - 'hub/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./hub
+        working-directory: hub
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/notification_build_test.yml
+++ b/.github/workflows/notification_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Notification - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './notification/**'
+      - 'notification/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./notification
+        working-directory: notification
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/order_build_test.yml
+++ b/.github/workflows/order_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Order - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './order/**'
+      - 'order/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./order
+        working-directory: order
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/product_build_test.yml
+++ b/.github/workflows/product_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: Product - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './product/**'
+      - 'product/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./product
+        working-directory: product
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/user_build_test.yml
+++ b/.github/workflows/user_build_test.yml
@@ -1,11 +1,11 @@
-name: 🚧 CI - Build & Test (Spring Boot)
+name: User - Build & Test (Spring Boot)
 
 on:
   pull_request:
     branches:
       - '**'
     paths:
-      - './user/**'
+      - 'user/**'
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./user
+        working-directory: user
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### #️⃣연관된 이슈
#17 

### 🪄작업 내용 
- PR에서 CI 자동 트리거가 동작하지 않아, 각 도메인별 워크플로우의 name 변경 및 paths, working-directory 스크립트 내 상대경로(./) 삭제하는 리팩토링 진행하였습니다.
