### PR TITLE
[feat] notification-service MSA 기본 설정

### DIFF
--- a/config/src/main/resources/config-repo/notification-service.yml
+++ b/config/src/main/resources/config-repo/notification-service.yml
@@ -1,0 +1,29 @@
+spring:
+  application:
+    name: notification-service
+  datasource:
+    url: jdbc:mysql://localhost:3306/hubEleven?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  cloud:
+    loadbalancer:
+      retry:
+        enabled: true
+
+server:
+  port: 0

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -29,9 +29,14 @@ ext {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/notification/settings.gradle
+++ b/notification/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'notification'

--- a/notification/src/main/resources/application.properties
+++ b/notification/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=notification

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: notification-service
+  config:
+    import: "configserver:"
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config
+
+server:
+  port: 0
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}

--- a/notification/src/test/java/com/hubEleven/notification/NotificationApplicationTests.java
+++ b/notification/src/test/java/com/hubEleven/notification/NotificationApplicationTests.java
@@ -5,7 +5,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class NotificationApplicationTests {
-
-	@Test
-	void contextLoads() {}
 }

--- a/notification/src/test/java/com/hubEleven/notification/NotificationApplicationTests.java
+++ b/notification/src/test/java/com/hubEleven/notification/NotificationApplicationTests.java
@@ -1,8 +1,6 @@
 package com.hubEleven.notification;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class NotificationApplicationTests {
-}
+class NotificationApplicationTests {}


### PR DESCRIPTION
### #️⃣연관된 이슈
> #28 

### 🪄작업 내용 
- notification: config 의존성 추가
- notification: yml 설정 추가
- config : config 서버의 notification-service.yml 설정 추가
