### PR TITLE
[feat] 허브경로(HubRoute) CRUD 구현

### DIFF
--- a/gateWay/src/main/resources/application.yml
+++ b/gateWay/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
               predicates:
                 - Path=/v1/hub-routes/**
 
+            - id: hub-service-hub-routes-internal
+              uri: lb://hub-service
+              predicates:
+                - Path=/v1/internal/hub-routes/**
+
             - id: order-service
               uri: lb://order-service
               predicates:

--- a/gateWay/src/main/resources/application.yml
+++ b/gateWay/src/main/resources/application.yml
@@ -25,10 +25,14 @@ spring:
               predicates:
                 - Path=/v1/products/**
 
-            - id: hub-service
+            - id: hub-service-hubs
               uri: lb://hub-service
               predicates:
                 - Path=/v1/hubs/**
+
+            - id: hub-service-hub-routes
+              uri: lb://hub-service
+              predicates:
                 - Path=/v1/hub-routes/**
 
             - id: order-service

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.hubEleven'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
@@ -39,6 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.github.Doritosch:commonLib:1.0.0'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/hubEleven/hub/application/dto/RouteResult.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/dto/RouteResult.java
@@ -1,0 +1,27 @@
+package com.hubEleven.hub.application.dto;
+
+import com.hubEleven.hub.domain.model.HubRoute;
+import java.util.List;
+import java.util.UUID;
+
+public record RouteResult(
+		UUID hubRouteId,
+		UUID fromHubId,
+		UUID toHubId,
+		Double totalDistance,
+		Integer totalDuration,
+		List<RouteSegmentResult> segments) {
+
+	public static RouteResult from(HubRoute hubRoute) {
+		List<RouteSegmentResult> segmentResults =
+				hubRoute.getSegments().stream().map(RouteSegmentResult::from).toList();
+
+		return new RouteResult(
+				hubRoute.getHubRouteId(),
+				hubRoute.getFromHubId(),
+				hubRoute.getToHubId(),
+				hubRoute.getTotalDistance(),
+				hubRoute.getTotalDuration(),
+				segmentResults);
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/dto/RouteSegmentResult.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/dto/RouteSegmentResult.java
@@ -1,0 +1,23 @@
+package com.hubEleven.hub.application.dto;
+
+import com.hubEleven.hub.domain.model.HubRouteSegment;
+import java.util.UUID;
+
+public record RouteSegmentResult(
+		UUID segmentId,
+		UUID fromHubId,
+		UUID toHubId,
+		Integer sequence,
+		Double distance,
+		Integer duration) {
+
+	public static RouteSegmentResult from(HubRouteSegment segment) {
+		return new RouteSegmentResult(
+				segment.getSegmentId(),
+				segment.getFromHubId(),
+				segment.getToHubId(),
+				segment.getSequence(),
+				segment.getDistance(),
+				segment.getDuration());
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
@@ -1,39 +1,53 @@
 package com.hubEleven.hub.application.service;
 
+import com.hubEleven.common.exception.GlobalException;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;
 import com.hubEleven.hub.application.dto.HubListResult;
 import com.hubEleven.hub.application.dto.HubResult;
+import com.hubEleven.hub.common.exception.HubErrorCode;
 import com.hubEleven.hub.domain.model.Hub;
 import com.hubEleven.hub.domain.repository.HubRepository;
+import com.hubEleven.hub.infrastructure.client.KakaoApiClient;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 public class HubServiceImpl implements HubService {
 
 	private final HubRepository hubRepository;
+	private final KakaoApiClient kakaoApiClient;
 
-	public HubServiceImpl(HubRepository hubRepository) {
+	public HubServiceImpl(HubRepository hubRepository, KakaoApiClient kakaoApiClient) {
 		this.hubRepository = hubRepository;
+		this.kakaoApiClient = kakaoApiClient;
 	}
 
 	/*
 	 *  1. 감사 로그 전체적으로 수정
-	 *  2. 허브 등록 및 수정 시 위도 경도 외부 API 연결 -> 주소를 통해 해당 주소의 위도 경도 받아오기 (Kakao Local API)
+	 *  2. 허브 등록 및 수정 시 위도 경도 외부 API 연결 -> 주소를 통해 해당 주소의 위도 경도 받아오기 (Kakao Local API) ✅
 	 *  3. Hub 위치 정보 수정 시 허브 경로 재배치
 	 *  4. createdBy/updatedBy/deletedBy를 Gateway 완성 후 받아오기
-	 *  5. Common 모듈의 예외로 교체
 	 * */
 	@Override
 	public HubResult createHub(CreateHubCommand command) {
-		// 중복 체크
-		if (hubRepository.existsByName(command.name())) {
-			throw new IllegalArgumentException("이미 동일한 이름의 허브가 존재합니다: " + command.name());
+
+		validateDuplicateName(command.name());
+
+		Double latitude = command.latitude();
+		Double longitude = command.longitude();
+
+		if (latitude == null || longitude == null) {
+			log.info("위도/경도 미입력, Kakao API로 geocoding 수행: address={}", command.address());
+			Double[] coordinates = kakaoApiClient.getCoordinates(command.address());
+			latitude = coordinates[0];
+			longitude = coordinates[1];
 		}
 
 		// 임시 값
@@ -43,8 +57,8 @@ public class HubServiceImpl implements HubService {
 				Hub.create(
 						command.name(),
 						command.address(),
-						command.latitude(),
-						command.longitude(),
+						latitude,
+						longitude,
 						command.regionCode(),
 						createdBy);
 
@@ -55,16 +69,10 @@ public class HubServiceImpl implements HubService {
 	@Override
 	public HubResult updateHub(UpdateHubCommand command) {
 		UUID hubId = command.hubId();
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 
-		// 이름 변경 시 중복 체크
 		if (command.name() != null && !command.name().equals(hub.getName())) {
-			if (hubRepository.existsByName(command.name())) {
-				throw new IllegalArgumentException("이미 동일한 이름의 허브가 존재합니다: " + command.name());
-			}
+			validateDuplicateName(command.name());
 		}
 
 		// 임시 값
@@ -86,10 +94,7 @@ public class HubServiceImpl implements HubService {
 	@Override
 	public void deleteHub(DeleteHubCommand command) {
 		UUID hubId = command.hubId();
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 
 		// 임시 값
 		Long deletedBy = 1L;
@@ -100,19 +105,27 @@ public class HubServiceImpl implements HubService {
 	@Override
 	@Transactional(readOnly = true)
 	public HubResult getHub(UUID hubId) {
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 		return HubResult.from(hub);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public HubListResult getHubs() {
-		// 삭제되지 않은 Hub만 조회
 		List<Hub> hubs = hubRepository.findAllNotDeleted();
 
 		return new HubListResult(hubs.stream().map(HubResult::from).toList());
+	}
+
+	private Hub findHubById(UUID hubId) {
+		return hubRepository
+				.findById(hubId)
+				.orElseThrow(() -> new GlobalException(HubErrorCode.HUB_NOT_FOUND));
+	}
+
+	private void validateDuplicateName(String name) {
+		if (hubRepository.existsByName(name)) {
+			throw new GlobalException(HubErrorCode.DUPLICATE_HUB_NAME);
+		}
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/application/service/RouteService.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/RouteService.java
@@ -1,0 +1,14 @@
+package com.hubEleven.hub.application.service;
+
+import com.hubEleven.hub.application.dto.RouteResult;
+import java.util.List;
+import java.util.UUID;
+
+public interface RouteService {
+
+	void generateAllRoutes();
+
+	List<RouteResult> getAllRoutes();
+
+	RouteResult findRoute(UUID departureHubId, UUID arrivalHubId);
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/service/RouteServiceImpl.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/RouteServiceImpl.java
@@ -1,0 +1,140 @@
+package com.hubEleven.hub.application.service;
+
+import com.hubEleven.common.exception.GlobalException;
+import com.hubEleven.hub.application.dto.RouteResult;
+import com.hubEleven.hub.application.util.RouteCalculationResult;
+import com.hubEleven.hub.application.util.RouteCalculator;
+import com.hubEleven.hub.common.exception.HubErrorCode;
+import com.hubEleven.hub.domain.model.Hub;
+import com.hubEleven.hub.domain.model.HubRoute;
+import com.hubEleven.hub.domain.model.HubRouteSegment;
+import com.hubEleven.hub.domain.repository.HubRepository;
+import com.hubEleven.hub.domain.repository.HubRouteRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RouteServiceImpl implements RouteService {
+
+	private final HubRepository hubRepository;
+	private final HubRouteRepository hubRouteRepository;
+	private final RouteCalculator routeCalculator;
+
+	@Override
+	@Transactional
+	public void generateAllRoutes() {
+		log.info("모든 허브 경로 생성 시작");
+
+		List<Hub> allHubs = hubRepository.findAllNotDeleted();
+
+		if (allHubs.size() < 2) {
+			log.warn("경로 생성 가능한 허브가 부족합니다. 현재 허브 수: {}", allHubs.size());
+			return;
+		}
+
+		int generatedCount = 0;
+
+		// 모든 허브 쌍에 대해 경로 생성
+		for (Hub fromHub : allHubs) {
+			for (Hub toHub : allHubs) {
+				if (fromHub.getHubId().equals(toHub.getHubId())) {
+					continue;
+				}
+
+				try {
+					// 기존 경로가 있으면 건너뛰기
+					if (hubRouteRepository
+							.findByFromHubIdAndToHubId(fromHub.getHubId(), toHub.getHubId())
+							.isPresent()) {
+						log.debug("이미 존재하는 경로: {} -> {}", fromHub.getName(), toHub.getName());
+						continue;
+					}
+
+					// 경로 계산
+					RouteCalculationResult calculationResult =
+							routeCalculator.calculate(fromHub.getHubId(), toHub.getHubId(), allHubs);
+
+					// Segment 생성
+					List<HubRouteSegment> segments = createSegments(calculationResult);
+
+					// 총 소요시간 계산
+					Integer totalDuration =
+							routeCalculator.calculateTotalDuration(calculationResult.segmentDistances());
+
+					// HubRoute 생성 및 저장
+					Long createdBy = 1L; // 임시값
+					HubRoute hubRoute =
+							HubRoute.create(
+									fromHub.getHubId(),
+									toHub.getHubId(),
+									calculationResult.totalDistance(),
+									totalDuration,
+									segments,
+									createdBy);
+
+					hubRouteRepository.save(hubRoute);
+					generatedCount++;
+
+					log.info(
+							"경로 생성 완료: {} -> {} (거리: {}km, 소요시간: {}분)",
+							fromHub.getName(),
+							toHub.getName(),
+							String.format("%.2f", calculationResult.totalDistance()),
+							totalDuration);
+
+				} catch (GlobalException e) {
+					log.warn("경로 생성 실패: {} -> {} ({})", fromHub.getName(), toHub.getName(), e.getMessage());
+				}
+			}
+		}
+
+		log.info("경로 생성 완료. 총 {}개 경로 생성됨", generatedCount);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<RouteResult> getAllRoutes() {
+		List<HubRoute> routes = hubRouteRepository.findAllNotDeleted();
+		return routes.stream().map(RouteResult::from).toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public RouteResult findRoute(UUID departureHubId, UUID arrivalHubId) {
+		HubRoute hubRoute =
+				hubRouteRepository
+						.findByFromHubIdAndToHubId(departureHubId, arrivalHubId)
+						.orElseThrow(() -> new GlobalException(HubErrorCode.ROUTE_NOT_FOUND));
+
+		return RouteResult.from(hubRoute);
+	}
+
+	private List<HubRouteSegment> createSegments(RouteCalculationResult calculationResult) {
+		List<HubRouteSegment> segments = new ArrayList<>();
+		List<UUID> path = calculationResult.path();
+		List<Double> distances = calculationResult.segmentDistances();
+
+		Long createdBy = 1L; // 임시값
+
+		for (int i = 0; i < distances.size(); i++) {
+			UUID fromHubId = path.get(i);
+			UUID toHubId = path.get(i + 1);
+			Double distance = distances.get(i);
+			Integer duration = routeCalculator.calculateDuration(distance);
+
+			HubRouteSegment segment =
+					HubRouteSegment.create(fromHubId, toHubId, i + 1, distance, duration, createdBy);
+
+			segments.add(segment);
+		}
+
+		return segments;
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/util/DistanceCalculator.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/util/DistanceCalculator.java
@@ -1,0 +1,25 @@
+package com.hubEleven.hub.application.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DistanceCalculator {
+
+	private static final double EARTH_RADIUS = 6378.137;
+
+	public Double calculate(Double lat1, Double lng1, Double lat2, Double lng2) {
+
+		double dLat = Math.toRadians(lat2 - lat1);
+		double dLng = Math.toRadians(lng2 - lng1);
+
+		double a =
+				Math.sin(dLat / 2) * Math.sin(dLat / 2)
+						+ Math.cos(Math.toRadians(lat1))
+								* Math.cos(Math.toRadians(lat2))
+								* Math.sin(dLng / 2)
+								* Math.sin(dLng / 2);
+		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+		return EARTH_RADIUS * c;
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/util/RouteCalculationResult.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/util/RouteCalculationResult.java
@@ -1,0 +1,7 @@
+package com.hubEleven.hub.application.util;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RouteCalculationResult(
+		List<UUID> path, List<Double> segmentDistances, Double totalDistance) {}

--- a/hub/src/main/java/com/hubEleven/hub/application/util/RouteCalculator.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/util/RouteCalculator.java
@@ -1,0 +1,165 @@
+package com.hubEleven.hub.application.util;
+
+import com.hubEleven.hub.domain.model.Hub;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RouteCalculator {
+
+	private static final double MAX_DIRECT_DISTANCE_KM = 200.0;
+	private static final double AVERAGE_SPEED_KM_PER_HOUR = 60.0;
+	private static final int HUB_PROCESSING_TIME_MINUTES = 30;
+
+	private final DistanceCalculator distanceCalculator;
+
+	public RouteCalculationResult calculate(UUID departureId, UUID arrivalId, List<Hub> allHubs) {
+
+		// 허브 맵 생성 (ID -> Hub)
+		Map<UUID, Hub> hubMap = new HashMap<>();
+		for (Hub hub : allHubs) {
+			hubMap.put(hub.getHubId(), hub);
+		}
+
+		// 그래프 구성 (인접 리스트)
+		Map<UUID, List<Edge>> graph = buildGraph(allHubs, hubMap);
+
+		// Dijkstra
+		Map<UUID, Double> distances = new HashMap<>();
+		Map<UUID, UUID> previous = new HashMap<>();
+		PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparingDouble(node -> node.distance));
+
+		// 초기화
+		for (Hub hub : allHubs) {
+			distances.put(hub.getHubId(), Double.MAX_VALUE);
+		}
+		distances.put(departureId, 0.0);
+		pq.offer(new Node(departureId, 0.0));
+
+		while (!pq.isEmpty()) {
+			Node current = pq.poll();
+			UUID currentId = current.hubId;
+
+			if (currentId.equals(arrivalId)) {
+				break;
+			}
+
+			if (current.distance > distances.get(currentId)) {
+				continue;
+			}
+
+			List<Edge> neighbors = graph.getOrDefault(currentId, Collections.emptyList());
+			for (Edge edge : neighbors) {
+				double newDist = distances.get(currentId) + edge.distance;
+				if (newDist < distances.get(edge.toHubId)) {
+					distances.put(edge.toHubId, newDist);
+					previous.put(edge.toHubId, currentId);
+					pq.offer(new Node(edge.toHubId, newDist));
+				}
+			}
+		}
+
+		List<UUID> path = reconstructPath(previous, departureId, arrivalId);
+		List<Double> segmentDistances = calculateSegmentDistances(path, hubMap);
+		Double totalDistance = distances.get(arrivalId);
+
+		return new RouteCalculationResult(path, segmentDistances, totalDistance);
+	}
+
+	// 각 구간별 소요 시간 계산 (분 단위)
+	public Integer calculateDuration(Double distance) {
+		return (int) Math.round((distance / AVERAGE_SPEED_KM_PER_HOUR) * 60);
+	}
+
+	// 전체 소요 시간 계산 (경유지 처리 시간 포함)
+	public Integer calculateTotalDuration(List<Double> segmentDistances) {
+		int travelTime = 0;
+		for (Double distance : segmentDistances) {
+			travelTime += calculateDuration(distance);
+		}
+
+		// 경유지 수 = 전체 구간 수 - 1
+		int viaHubCount = Math.max(0, segmentDistances.size() - 1);
+		int processingTime = viaHubCount * HUB_PROCESSING_TIME_MINUTES;
+
+		return travelTime + processingTime;
+	}
+
+	// 그래프 구성 (200km 이하만 연결)
+	private Map<UUID, List<Edge>> buildGraph(List<Hub> allHubs, Map<UUID, Hub> hubMap) {
+		Map<UUID, List<Edge>> graph = new HashMap<>();
+
+		for (Hub from : allHubs) {
+			List<Edge> edges = new ArrayList<>();
+			for (Hub to : allHubs) {
+				if (from.getHubId().equals(to.getHubId())) {
+					continue;
+				}
+
+				double distance =
+						distanceCalculator.calculate(
+								from.getLocation().getLatitude(),
+								from.getLocation().getLongitude(),
+								to.getLocation().getLatitude(),
+								to.getLocation().getLongitude());
+
+				if (distance <= MAX_DIRECT_DISTANCE_KM) {
+					edges.add(new Edge(to.getHubId(), distance));
+				}
+			}
+			graph.put(from.getHubId(), edges);
+		}
+
+		return graph;
+	}
+
+	// 경로 복원
+	private List<UUID> reconstructPath(Map<UUID, UUID> previous, UUID departureId, UUID arrivalId) {
+		List<UUID> path = new ArrayList<>();
+		UUID current = arrivalId;
+
+		while (current != null) {
+			path.add(current);
+			current = previous.get(current);
+		}
+
+		Collections.reverse(path);
+		return path;
+	}
+
+	// 구간별 거리 계산
+	private List<Double> calculateSegmentDistances(List<UUID> path, Map<UUID, Hub> hubMap) {
+		List<Double> distances = new ArrayList<>();
+
+		for (int i = 0; i < path.size() - 1; i++) {
+			Hub from = hubMap.get(path.get(i));
+			Hub to = hubMap.get(path.get(i + 1));
+
+			double distance =
+					distanceCalculator.calculate(
+							from.getLocation().getLatitude(),
+							from.getLocation().getLongitude(),
+							to.getLocation().getLatitude(),
+							to.getLocation().getLongitude());
+
+			distances.add(distance);
+		}
+
+		return distances;
+	}
+
+	// Dijkstra용 노드
+	private record Node(UUID hubId, Double distance) {}
+
+	// 그래프 간선
+	private record Edge(UUID toHubId, Double distance) {}
+}

--- a/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
+++ b/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
@@ -1,0 +1,23 @@
+package com.hubEleven.hub.common.exception;
+
+import com.hubEleven.common.code.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubErrorCode implements StatusCode {
+	DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 동일한 이름의 허브가 존재합니다."),
+	HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "허브를 찾을 수 없습니다."),
+	GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "주소로부터 좌표를 찾을 수 없습니다."),
+	KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API 호출 중 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String getName() {
+		return this.name();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
+++ b/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
@@ -11,7 +11,8 @@ public enum HubErrorCode implements StatusCode {
 	DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 동일한 이름의 허브가 존재합니다."),
 	HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "허브를 찾을 수 없습니다."),
 	GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "주소로부터 좌표를 찾을 수 없습니다."),
-	KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API 호출 중 오류가 발생했습니다.");
+	KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API 호출 중 오류가 발생했습니다."),
+	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "경로를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/hub/src/main/java/com/hubEleven/hub/domain/model/HubRoute.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/model/HubRoute.java
@@ -1,13 +1,17 @@
 package com.hubEleven.hub.domain.model;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,16 +32,21 @@ public class HubRoute {
 	private UUID hubRouteId;
 
 	@Column(name = "from_hub_id", nullable = false)
-	private UUID fromHub;
+	private UUID fromHubId;
 
 	@Column(name = "to_hub_id", nullable = false)
-	private UUID toHub;
+	private UUID toHubId;
 
-	@Column(name = "distance", precision = 10, scale = 2, nullable = false)
-	private BigDecimal distance;
+	@Column(name = "total_distance", nullable = false)
+	private Double totalDistance;
 
-	@Column(name = "duration", nullable = false)
-	private Long duration;
+	@Column(name = "total_duration", nullable = false)
+	private Integer totalDuration;
+
+	@OneToMany(mappedBy = "hubRoute", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("sequence ASC")
+	@Builder.Default
+	private List<HubRouteSegment> segments = new ArrayList<>();
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
@@ -56,4 +65,43 @@ public class HubRoute {
 
 	@Column(name = "deleted_by")
 	private Long deletedBy;
+
+	public static HubRoute create(
+			UUID fromHubId,
+			UUID toHubId,
+			Double totalDistance,
+			Integer totalDuration,
+			List<HubRouteSegment> segments,
+			Long createdBy) {
+
+		HubRoute hubRoute =
+				HubRoute.builder()
+						.fromHubId(fromHubId)
+						.toHubId(toHubId)
+						.totalDistance(totalDistance)
+						.totalDuration(totalDuration)
+						.createdAt(LocalDateTime.now())
+						.createdBy(createdBy)
+						.build();
+
+		for (HubRouteSegment segment : segments) {
+			hubRoute.addSegment(segment);
+		}
+
+		return hubRoute;
+	}
+
+	public void addSegment(HubRouteSegment segment) {
+		this.segments.add(segment);
+		segment.setHubRoute(this);
+	}
+
+	public void softDelete(Long deletedBy) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = deletedBy;
+	}
+
+	public boolean isDeleted() {
+		return deletedAt != null;
+	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/domain/model/HubRouteSegment.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/model/HubRouteSegment.java
@@ -1,0 +1,79 @@
+package com.hubEleven.hub.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "p_hub_route_segment")
+public class HubRouteSegment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID segmentId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "hub_route_id", nullable = false)
+	private HubRoute hubRoute;
+
+	@Column(name = "from_hub_id", nullable = false)
+	private UUID fromHubId;
+
+	@Column(name = "to_hub_id", nullable = false)
+	private UUID toHubId;
+
+	@Column(name = "sequence", nullable = false)
+	private Integer sequence;
+
+	@Column(name = "distance", nullable = false)
+	private Double distance;
+
+	@Column(name = "duration", nullable = false)
+	private Integer duration;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "created_by", nullable = false)
+	private Long createdBy;
+
+	public static HubRouteSegment create(
+			UUID fromHubId,
+			UUID toHubId,
+			Integer sequence,
+			Double distance,
+			Integer duration,
+			Long createdBy) {
+
+		return HubRouteSegment.builder()
+				.fromHubId(fromHubId)
+				.toHubId(toHubId)
+				.sequence(sequence)
+				.distance(distance)
+				.duration(duration)
+				.createdAt(LocalDateTime.now())
+				.createdBy(createdBy)
+				.build();
+	}
+
+	void setHubRoute(HubRoute hubRoute) {
+		this.hubRoute = hubRoute;
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/domain/repository/HubRouteRepository.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/repository/HubRouteRepository.java
@@ -1,0 +1,19 @@
+package com.hubEleven.hub.domain.repository;
+
+import com.hubEleven.hub.domain.model.HubRoute;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HubRouteRepository {
+
+	HubRoute save(HubRoute hubRoute);
+
+	Optional<HubRoute> findById(UUID hubRouteId);
+
+	Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+
+	List<HubRoute> findAll();
+
+	List<HubRoute> findAllNotDeleted();
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
@@ -1,0 +1,80 @@
+package com.hubEleven.hub.infrastructure.client;
+
+import com.hubEleven.common.exception.GlobalException;
+import com.hubEleven.hub.common.exception.HubErrorCode;
+import com.hubEleven.hub.infrastructure.config.KakaoApiProperties;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+
+	private final KakaoApiProperties properties;
+
+	public Double[] getCoordinates(String address) {
+		try {
+			String query = URLEncoder.encode(address, StandardCharsets.UTF_8);
+			String urlString = "https://dapi.kakao.com/v2/local/search/address.json?query=" + query;
+
+			log.info("Kakao API 호출: address={}", address);
+			log.info("Request URL: {}", urlString);
+
+			HttpURLConnection conn = (HttpURLConnection) new URL(urlString).openConnection();
+			conn.setRequestMethod("GET");
+			conn.setRequestProperty("Authorization", "KakaoAK " + properties.getKey());
+
+			int status = conn.getResponseCode();
+			InputStream is =
+					(status == HttpURLConnection.HTTP_OK) ? conn.getInputStream() : conn.getErrorStream();
+
+			StringBuilder sb = new StringBuilder();
+			try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+					BufferedReader br = new BufferedReader(isr)) {
+				String line;
+				while ((line = br.readLine()) != null) {
+					sb.append(line);
+				}
+			}
+
+			String json = sb.toString();
+			log.info("Kakao API 응답: status={}, body={}", status, json);
+
+			if (status != HttpURLConnection.HTTP_OK) {
+				log.error("Kakao API 호출 실패: status={}, body={}", status, json);
+				throw new GlobalException(HubErrorCode.KAKAO_API_ERROR);
+			}
+
+			// 좌표 파싱
+			if (!json.contains("\"x\":\"") || !json.contains("\"y\":\"")) {
+				log.warn("주소 검색 결과 없음: address={}", address);
+				throw new GlobalException(HubErrorCode.GEOCODING_FAILED);
+			}
+
+			String longitude = json.split("\"x\":\"")[1].split("\"")[0];
+			String latitude = json.split("\"y\":\"")[1].split("\"")[0];
+
+			Double lat = Double.parseDouble(latitude);
+			Double lon = Double.parseDouble(longitude);
+
+			log.info("Geocoding 성공: address={}, lat={}, lon={}", address, lat, lon);
+
+			return new Double[] {lat, lon};
+
+		} catch (GlobalException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Kakao API 호출 중 예외 발생: {}", e.getMessage(), e);
+			throw new GlobalException(HubErrorCode.KAKAO_API_ERROR);
+		}
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/client/dto/KakaoGeocodingResponse.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/client/dto/KakaoGeocodingResponse.java
@@ -1,0 +1,25 @@
+package com.hubEleven.hub.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoGeocodingResponse(List<Document> documents, Meta meta) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Document(
+			@JsonProperty("address_name") String addressName,
+			@JsonProperty("x") String longitude,
+			@JsonProperty("y") String latitude) {}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Meta(@JsonProperty("total_count") int totalCount) {}
+
+	public boolean hasResult() {
+		return documents != null && !documents.isEmpty();
+	}
+
+	public Document getFirstDocument() {
+		return documents.get(0);
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/HubDataInitializer.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/HubDataInitializer.java
@@ -1,0 +1,107 @@
+package com.hubEleven.hub.infrastructure.config;
+
+import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.domain.model.Hub;
+import com.hubEleven.hub.domain.repository.HubRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubDataInitializer implements CommandLineRunner {
+
+	private final HubRepository hubRepository;
+	private final RouteService routeService;
+
+	@Override
+	public void run(String... args) {
+		// DB에 허브가 이미 존재하면 스킵
+		List<Hub> existingHubs = hubRepository.findAll();
+		if (!existingHubs.isEmpty()) {
+			log.info("기존 허브 데이터가 존재하여 초기화를 건너뜁니다. (총 {}개)", existingHubs.size());
+			return;
+		}
+
+		log.info("초기 허브 데이터 생성을 시작합니다.");
+
+		try {
+			createInitialHubs();
+			log.info("초기 허브 데이터 생성 완료");
+
+			log.info("허브 경로 생성을 시작합니다.");
+			routeService.generateAllRoutes();
+			log.info("허브 경로 생성 완료");
+
+		} catch (Exception e) {
+			log.error("초기 데이터 생성 중 오류 발생", e);
+		}
+	}
+
+	private void createInitialHubs() {
+		List<HubData> hubDataList =
+				List.of(
+						new HubData(
+								"서울특별시 센터", "서울특별시 송파구 송파대로 55", 37.4742027808565, 127.123621185562, "SEOUL"),
+						new HubData(
+								"경기 북부 센터",
+								"경기도 고양시 덕양구 권율대로 570",
+								37.6403771056018,
+								126.87379545786,
+								"GYEONGGI_NORTH"),
+						new HubData(
+								"경기 남부 센터",
+								"경기도 이천시 덕평로 257-21",
+								37.1896213142136,
+								127.375050006958,
+								"GYEONGGI_SOUTH"),
+						new HubData("부산광역시 센터", "부산 동구 중앙대로 206", 35.117605126596, 129.045060216345, "BUSAN"),
+						new HubData("대구광역시 센터", "대구 북구 태평로 161", 35.8858, 128.5931, "DAEGU"),
+						new HubData("인천광역시 센터", "인천 남동구 정각로 29", 37.4560499608337, 126.705255744089, "INCHEON"),
+						new HubData("광주광역시 센터", "광주 서구 내방로 111", 35.1600994105234, 126.851461925213, "GWANGJU"),
+						new HubData("대전광역시 센터", "대전 서구 둔산로 100", 36.3503849976553, 127.384633005948, "DAEJEON"),
+						new HubData("울산광역시 센터", "울산 남구 중앙로 201", 35.5390270962011, 129.311356392207, "ULSAN"),
+						new HubData(
+								"세종특별자치시 센터", "세종특별자치시 한누리대로 2130", 36.4800579897497, 127.289039408864, "SEJONG"),
+						new HubData(
+								"강원특별자치도 센터", "강원특별자치도 춘천시 중앙로 1", 37.8800729197963, 127.727907820318, "GANGWON"),
+						new HubData(
+								"충청북도 센터", "충북 청주시 상당구 상당로 82", 36.6353867908159, 127.491428436987, "CHUNGBUK"),
+						new HubData(
+								"충청남도 센터", "충남 홍성군 홍북읍 충남대로 21", 36.6590416999343, 126.673057036952, "CHUNGNAM"),
+						new HubData(
+								"전북특별자치도 센터",
+								"전북특별자치도 전주시 완산구 효자로 225",
+								35.8194621650578,
+								127.106396942356,
+								"JEONBUK"),
+						new HubData(
+								"전라남도 센터", "전남 무안군 삼향읍 오룡길 1", 34.8174727676363, 126.465415935304, "JEONNAM"),
+						new HubData(
+								"경상북도 센터", "경북 안동시 풍천면 도청대로 455", 36.5761205474728, 128.505722686385, "GYEONGBUK"),
+						new HubData(
+								"경상남도 센터", "경남 창원시 의창구 중앙대로 300", 35.2378032514675, 128.691940442146, "GYEONGNAM"));
+
+		Long createdBy = 1L; // 시스템 생성
+
+		for (HubData data : hubDataList) {
+			try {
+				Hub hub =
+						Hub.create(
+								data.name, data.address, data.latitude, data.longitude, data.regionCode, createdBy);
+
+				hubRepository.save(hub);
+				log.info("허브 생성: {} ({})", data.name, data.address);
+
+			} catch (Exception e) {
+				log.error("허브 생성 실패: {} - {}", data.name, e.getMessage());
+			}
+		}
+	}
+
+	private record HubData(
+			String name, String address, Double latitude, Double longitude, String regionCode) {}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/KakaoApiProperties.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/KakaoApiProperties.java
@@ -1,0 +1,15 @@
+package com.hubEleven.hub.infrastructure.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakao.api")
+public class KakaoApiProperties {
+	private String key;
+	private String baseUrl;
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRepositoryAdapter.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRepositoryAdapter.java
@@ -1,4 +1,4 @@
-package com.hubEleven.hub.infrastructure;
+package com.hubEleven.hub.infrastructure.repository;
 
 import com.hubEleven.hub.domain.model.Hub;
 import com.hubEleven.hub.domain.repository.HubRepository;

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRouteRepositoryAdapter.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRouteRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package com.hubEleven.hub.infrastructure.repository;
+
+import com.hubEleven.hub.domain.model.HubRoute;
+import com.hubEleven.hub.domain.repository.HubRouteRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRouteRepositoryAdapter implements HubRouteRepository {
+
+	private final JpaHubRouteRepository jpaHubRouteRepository;
+
+	@Override
+	public HubRoute save(HubRoute hubRoute) {
+		return jpaHubRouteRepository.save(hubRoute);
+	}
+
+	@Override
+	public Optional<HubRoute> findById(UUID hubRouteId) {
+		return jpaHubRouteRepository.findById(hubRouteId);
+	}
+
+	@Override
+	public Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId) {
+		return jpaHubRouteRepository.findByFromHubIdAndToHubId(fromHubId, toHubId);
+	}
+
+	@Override
+	public List<HubRoute> findAll() {
+		return jpaHubRouteRepository.findAll();
+	}
+
+	@Override
+	public List<HubRoute> findAllNotDeleted() {
+		return jpaHubRouteRepository.findAllNotDeleted();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRepository.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRepository.java
@@ -1,4 +1,4 @@
-package com.hubEleven.hub.infrastructure;
+package com.hubEleven.hub.infrastructure.repository;
 
 import com.hubEleven.hub.domain.model.Hub;
 import java.util.List;

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -1,0 +1,16 @@
+package com.hubEleven.hub.infrastructure.repository;
+
+import com.hubEleven.hub.domain.model.HubRoute;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
+
+	@Query("SELECT hr FROM HubRoute hr WHERE hr.deletedAt IS NULL")
+	List<HubRoute> findAllNotDeleted();
+
+	Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
@@ -1,5 +1,7 @@
 package com.hubEleven.hub.presentation;
 
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;
@@ -14,6 +16,8 @@ import com.hubEleven.hub.presentation.dto.response.HubResponseDto;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,45 +29,48 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/hubs")
+@RequiredArgsConstructor
 public class HubController {
 
 	private final HubService hubService;
 
-	public HubController(HubService hubService) {
-		this.hubService = hubService;
-	}
-
 	@PostMapping
-	public HubResponseDto createHub(@Valid @RequestBody HubCreateRequestDto request) {
+	public ResponseEntity<ApiResponse<HubResponseDto>> createHub(
+			@Valid @RequestBody HubCreateRequestDto request) {
 		CreateHubCommand command = request.toCommand();
 		HubResult result = hubService.createHub(command);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@PatchMapping("/{hubId}")
-	public HubResponseDto updateHub(
+	public ResponseEntity<ApiResponse<HubResponseDto>> updateHub(
 			@PathVariable UUID hubId, @Valid @RequestBody HubUpdateRequestDto request) {
 		UpdateHubCommand command = request.toCommand(hubId);
 		HubResult result = hubService.updateHub(command);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@DeleteMapping("/{hubId}")
-	public HubDeleteResponseDto deleteHub(@PathVariable UUID hubId) {
+	public ResponseEntity<ApiResponse<HubDeleteResponseDto>> deleteHub(@PathVariable UUID hubId) {
 		hubService.deleteHub(new DeleteHubCommand(hubId));
-		return new HubDeleteResponseDto(hubId, true);
+		HubDeleteResponseDto response = new HubDeleteResponseDto(hubId, true);
+		return ApiResponseEntity.success(response);
 	}
 
 	@GetMapping("/{hubId}")
-	public HubResponseDto getHub(@PathVariable UUID hubId) {
+	public ResponseEntity<ApiResponse<HubResponseDto>> getHub(@PathVariable UUID hubId) {
 		HubResult result = hubService.getHub(hubId);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@GetMapping
-	public HubListResponseDto getHubs() {
+	public ResponseEntity<ApiResponse<HubListResponseDto>> getHubs() {
 		HubListResult result = hubService.getHubs();
 		List<HubResponseDto> responses = HubResponseDto.fromList(result.hubs());
-		return new HubListResponseDto(responses);
+		HubListResponseDto response = new HubListResponseDto(responses);
+		return ApiResponseEntity.success(response);
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/presentation/HubRouteController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/HubRouteController.java
@@ -1,0 +1,45 @@
+package com.hubEleven.hub.presentation;
+
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
+import com.hubEleven.hub.application.dto.RouteResult;
+import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.presentation.dto.response.HubRouteResponseDto;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/hub-routes")
+@RequiredArgsConstructor
+public class HubRouteController {
+
+	private final RouteService routeService;
+
+	@PostMapping("/generate")
+	public ResponseEntity<ApiResponse<String>> generateAllRoutes() {
+		routeService.generateAllRoutes();
+		return ApiResponseEntity.success("모든 경로 생성이 완료되었습니다.");
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<HubRouteResponseDto>>> getAllRoutes() {
+		List<RouteResult> results = routeService.getAllRoutes();
+		List<HubRouteResponseDto> response = HubRouteResponseDto.fromList(results);
+		return ApiResponseEntity.success(response);
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<HubRouteResponseDto>> searchRoute(
+			@RequestParam UUID fromHubId, @RequestParam UUID toHubId) {
+		RouteResult result = routeService.findRoute(fromHubId, toHubId);
+		HubRouteResponseDto response = HubRouteResponseDto.from(result);
+		return ApiResponseEntity.success(response);
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/dto/request/HubCreateRequestDto.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/dto/request/HubCreateRequestDto.java
@@ -4,7 +4,6 @@ import com.hubEleven.hub.application.command.CreateHubCommand;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record HubCreateRequestDto(
@@ -12,12 +11,9 @@ public record HubCreateRequestDto(
 				String name,
 		@NotBlank(message = "주소는 필수 입력 항목입니다.") @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
 				String address,
-		@NotNull(message = "위도는 필수 입력 항목입니다.")
-				@Min(value = -90, message = "위도는 -90 이상이어야 합니다.")
-				@Max(value = 90, message = "위도는 90 이하여야 합니다.")
+		@Min(value = -90, message = "위도는 -90 이상이어야 합니다.") @Max(value = 90, message = "위도는 90 이하여야 합니다.")
 				Double latitude,
-		@NotNull(message = "경도는 필수 입력 항목입니다.")
-				@Min(value = -180, message = "경도는 -180 이상이어야 합니다.")
+		@Min(value = -180, message = "경도는 -180 이상이어야 합니다.")
 				@Max(value = 180, message = "경도는 180 이하여야 합니다.")
 				Double longitude,
 		@NotBlank(message = "지역 코드는 필수 입력 항목입니다.") @Size(max = 50, message = "지역 코드는 50자 이하여야 합니다.")

--- a/hub/src/main/java/com/hubEleven/hub/presentation/dto/response/HubRouteResponseDto.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/dto/response/HubRouteResponseDto.java
@@ -1,0 +1,31 @@
+package com.hubEleven.hub.presentation.dto.response;
+
+import com.hubEleven.hub.application.dto.RouteResult;
+import java.util.List;
+import java.util.UUID;
+
+public record HubRouteResponseDto(
+		UUID hubRouteId,
+		UUID fromHubId,
+		UUID toHubId,
+		Double totalDistance,
+		Integer totalDuration,
+		List<HubRouteSegmentResponseDto> segments) {
+
+	public static HubRouteResponseDto from(RouteResult result) {
+		List<HubRouteSegmentResponseDto> segmentResponses =
+				result.segments().stream().map(HubRouteSegmentResponseDto::from).toList();
+
+		return new HubRouteResponseDto(
+				result.hubRouteId(),
+				result.fromHubId(),
+				result.toHubId(),
+				result.totalDistance(),
+				result.totalDuration(),
+				segmentResponses);
+	}
+
+	public static List<HubRouteResponseDto> fromList(List<RouteResult> results) {
+		return results.stream().map(HubRouteResponseDto::from).toList();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/dto/response/HubRouteSegmentResponseDto.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/dto/response/HubRouteSegmentResponseDto.java
@@ -1,0 +1,23 @@
+package com.hubEleven.hub.presentation.dto.response;
+
+import com.hubEleven.hub.application.dto.RouteSegmentResult;
+import java.util.UUID;
+
+public record HubRouteSegmentResponseDto(
+		UUID segmentId,
+		UUID fromHubId,
+		UUID toHubId,
+		Integer sequence,
+		Double distance,
+		Integer duration) {
+
+	public static HubRouteSegmentResponseDto from(RouteSegmentResult result) {
+		return new HubRouteSegmentResponseDto(
+				result.segmentId(),
+				result.fromHubId(),
+				result.toHubId(),
+				result.sequence(),
+				result.distance(),
+				result.duration());
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/internal/InternalHubRouteController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/internal/InternalHubRouteController.java
@@ -1,0 +1,38 @@
+package com.hubEleven.hub.presentation.internal;
+
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
+import com.hubEleven.hub.application.dto.RouteResult;
+import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.presentation.dto.response.HubRouteResponseDto;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/internal/hub-routes")
+@RequiredArgsConstructor
+public class InternalHubRouteController {
+
+	private final RouteService routeService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<HubRouteResponseDto>>> getAllRoutes() {
+		List<RouteResult> results = routeService.getAllRoutes();
+		List<HubRouteResponseDto> response = HubRouteResponseDto.fromList(results);
+		return ApiResponseEntity.success(response);
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<HubRouteResponseDto>> searchRoute(
+			@RequestParam UUID fromHubId, @RequestParam UUID toHubId) {
+		RouteResult result = routeService.findRoute(fromHubId, toHubId);
+		HubRouteResponseDto response = HubRouteResponseDto.from(result);
+		return ApiResponseEntity.success(response);
+	}
+}

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -9,4 +9,7 @@ spring:
         enabled: true
         service-id: config
 
-
+kakao:
+  api:
+    key: ${KAKAO_REST_API_KEY}
+    base-url: https://dapi.kakao.com


### PR DESCRIPTION
### #️⃣연관된 이슈
#46

### 🪄작업 내용
- P2P + Hub to Hub Relay 방식 사용
- HubRoute, HubRouteSegment Entity 및 Repository 구현
- HubRoute 만으로 관리가 힘들어서 하위테이블(서울 - 부산일 경우 어느 곳을 거쳐야 하는지 관리하는 테이블)을 추가했습니다.
- Dijkstra 알고리즘 기반 최단 경로 계산 (200km 직접 연결, 초과 시 경유)
- 경로 생성/조회 API (외부용, 내부용 분리)
- 애플리케이션 시작 시 초기 허브 및 경로 데이터 자동 생성

### ✏️리뷰 요청
- 경로 계산 로직은 더 개선하겠습니다.
- 내부/외부 API 분리 구조 괜찮은지 궁금합니다.
- 추가적으로 응답에 필요한 데이터가 있을까요?