### PR TITLE
[feat] 허브(Hub)  KAKAO API 연동 및 공통 모듈 적용 

### DIFF
--- a/gateWay/src/main/resources/application.yml
+++ b/gateWay/src/main/resources/application.yml
@@ -25,10 +25,14 @@ spring:
               predicates:
                 - Path=/v1/products/**
 
-            - id: hub-service
+            - id: hub-service-hubs
               uri: lb://hub-service
               predicates:
                 - Path=/v1/hubs/**
+
+            - id: hub-service-hub-routes
+              uri: lb://hub-service
+              predicates:
                 - Path=/v1/hub-routes/**
 
             - id: order-service

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.hubEleven'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
@@ -39,6 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.github.Doritosch:commonLib:1.0.0'
 }
 
 dependencyManagement {

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.hubEleven'
-version = '0.0.2-SNAPSHOT'
+version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.github.Doritosch:commonLib:1.0.0'
+    implementation 'com.github.Doritosch:commonLib:1.0.2'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
@@ -1,6 +1,6 @@
 package com.hubEleven.hub.application.service;
 
-import com.hubEleven.common.exception.GlobalException;
+import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;
@@ -31,9 +31,8 @@ public class HubServiceImpl implements HubService {
 
 	/*
 	 *  1. 감사 로그 전체적으로 수정
-	 *  2. 허브 등록 및 수정 시 위도 경도 외부 API 연결 -> 주소를 통해 해당 주소의 위도 경도 받아오기 (Kakao Local API) ✅
-	 *  3. Hub 위치 정보 수정 시 허브 경로 재배치
-	 *  4. createdBy/updatedBy/deletedBy를 Gateway 완성 후 받아오기
+	 *  2. Hub 위치 정보 수정 시 허브 경로 재배치
+	 *  3. createdBy/updatedBy/deletedBy를 Gateway 완성 후 받아오기
 	 * */
 	@Override
 	public HubResult createHub(CreateHubCommand command) {

--- a/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/HubServiceImpl.java
@@ -1,39 +1,53 @@
 package com.hubEleven.hub.application.service;
 
+import com.hubEleven.common.exception.GlobalException;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;
 import com.hubEleven.hub.application.dto.HubListResult;
 import com.hubEleven.hub.application.dto.HubResult;
+import com.hubEleven.hub.common.exception.HubErrorCode;
 import com.hubEleven.hub.domain.model.Hub;
 import com.hubEleven.hub.domain.repository.HubRepository;
+import com.hubEleven.hub.infrastructure.client.KakaoApiClient;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 public class HubServiceImpl implements HubService {
 
 	private final HubRepository hubRepository;
+	private final KakaoApiClient kakaoApiClient;
 
-	public HubServiceImpl(HubRepository hubRepository) {
+	public HubServiceImpl(HubRepository hubRepository, KakaoApiClient kakaoApiClient) {
 		this.hubRepository = hubRepository;
+		this.kakaoApiClient = kakaoApiClient;
 	}
 
 	/*
 	 *  1. 감사 로그 전체적으로 수정
-	 *  2. 허브 등록 및 수정 시 위도 경도 외부 API 연결 -> 주소를 통해 해당 주소의 위도 경도 받아오기 (Kakao Local API)
+	 *  2. 허브 등록 및 수정 시 위도 경도 외부 API 연결 -> 주소를 통해 해당 주소의 위도 경도 받아오기 (Kakao Local API) ✅
 	 *  3. Hub 위치 정보 수정 시 허브 경로 재배치
 	 *  4. createdBy/updatedBy/deletedBy를 Gateway 완성 후 받아오기
-	 *  5. Common 모듈의 예외로 교체
 	 * */
 	@Override
 	public HubResult createHub(CreateHubCommand command) {
-		// 중복 체크
-		if (hubRepository.existsByName(command.name())) {
-			throw new IllegalArgumentException("이미 동일한 이름의 허브가 존재합니다: " + command.name());
+
+		validateDuplicateName(command.name());
+
+		Double latitude = command.latitude();
+		Double longitude = command.longitude();
+
+		if (latitude == null || longitude == null) {
+			log.info("위도/경도 미입력, Kakao API로 geocoding 수행: address={}", command.address());
+			Double[] coordinates = kakaoApiClient.getCoordinates(command.address());
+			latitude = coordinates[0];
+			longitude = coordinates[1];
 		}
 
 		// 임시 값
@@ -43,8 +57,8 @@ public class HubServiceImpl implements HubService {
 				Hub.create(
 						command.name(),
 						command.address(),
-						command.latitude(),
-						command.longitude(),
+						latitude,
+						longitude,
 						command.regionCode(),
 						createdBy);
 
@@ -55,16 +69,10 @@ public class HubServiceImpl implements HubService {
 	@Override
 	public HubResult updateHub(UpdateHubCommand command) {
 		UUID hubId = command.hubId();
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 
-		// 이름 변경 시 중복 체크
 		if (command.name() != null && !command.name().equals(hub.getName())) {
-			if (hubRepository.existsByName(command.name())) {
-				throw new IllegalArgumentException("이미 동일한 이름의 허브가 존재합니다: " + command.name());
-			}
+			validateDuplicateName(command.name());
 		}
 
 		// 임시 값
@@ -86,10 +94,7 @@ public class HubServiceImpl implements HubService {
 	@Override
 	public void deleteHub(DeleteHubCommand command) {
 		UUID hubId = command.hubId();
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 
 		// 임시 값
 		Long deletedBy = 1L;
@@ -100,19 +105,27 @@ public class HubServiceImpl implements HubService {
 	@Override
 	@Transactional(readOnly = true)
 	public HubResult getHub(UUID hubId) {
-		Hub hub =
-				hubRepository
-						.findById(hubId)
-						.orElseThrow(() -> new IllegalArgumentException("해당 허브를 찾을 수 없습니다: " + hubId));
+		Hub hub = findHubById(hubId);
 		return HubResult.from(hub);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public HubListResult getHubs() {
-		// 삭제되지 않은 Hub만 조회
 		List<Hub> hubs = hubRepository.findAllNotDeleted();
 
 		return new HubListResult(hubs.stream().map(HubResult::from).toList());
+	}
+
+	private Hub findHubById(UUID hubId) {
+		return hubRepository
+				.findById(hubId)
+				.orElseThrow(() -> new GlobalException(HubErrorCode.HUB_NOT_FOUND));
+	}
+
+	private void validateDuplicateName(String name) {
+		if (hubRepository.existsByName(name)) {
+			throw new GlobalException(HubErrorCode.DUPLICATE_HUB_NAME);
+		}
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
+++ b/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
@@ -1,6 +1,6 @@
 package com.hubEleven.hub.common.exception;
 
-import com.hubEleven.common.code.StatusCode;
+import com.commonLib.common.code.StatusCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
+++ b/hub/src/main/java/com/hubEleven/hub/common/exception/HubErrorCode.java
@@ -1,0 +1,23 @@
+package com.hubEleven.hub.common.exception;
+
+import com.hubEleven.common.code.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubErrorCode implements StatusCode {
+	DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 동일한 이름의 허브가 존재합니다."),
+	HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "허브를 찾을 수 없습니다."),
+	GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "주소로부터 좌표를 찾을 수 없습니다."),
+	KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API 호출 중 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String getName() {
+		return this.name();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
@@ -1,6 +1,6 @@
 package com.hubEleven.hub.infrastructure.client;
 
-import com.hubEleven.common.exception.GlobalException;
+import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.hub.common.exception.HubErrorCode;
 import com.hubEleven.hub.infrastructure.config.KakaoApiProperties;
 import java.io.BufferedReader;

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/client/KakaoApiClient.java
@@ -1,0 +1,80 @@
+package com.hubEleven.hub.infrastructure.client;
+
+import com.hubEleven.common.exception.GlobalException;
+import com.hubEleven.hub.common.exception.HubErrorCode;
+import com.hubEleven.hub.infrastructure.config.KakaoApiProperties;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+
+	private final KakaoApiProperties properties;
+
+	public Double[] getCoordinates(String address) {
+		try {
+			String query = URLEncoder.encode(address, StandardCharsets.UTF_8);
+			String urlString = "https://dapi.kakao.com/v2/local/search/address.json?query=" + query;
+
+			log.info("Kakao API 호출: address={}", address);
+			log.info("Request URL: {}", urlString);
+
+			HttpURLConnection conn = (HttpURLConnection) new URL(urlString).openConnection();
+			conn.setRequestMethod("GET");
+			conn.setRequestProperty("Authorization", "KakaoAK " + properties.getKey());
+
+			int status = conn.getResponseCode();
+			InputStream is =
+					(status == HttpURLConnection.HTTP_OK) ? conn.getInputStream() : conn.getErrorStream();
+
+			StringBuilder sb = new StringBuilder();
+			try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+					BufferedReader br = new BufferedReader(isr)) {
+				String line;
+				while ((line = br.readLine()) != null) {
+					sb.append(line);
+				}
+			}
+
+			String json = sb.toString();
+			log.info("Kakao API 응답: status={}, body={}", status, json);
+
+			if (status != HttpURLConnection.HTTP_OK) {
+				log.error("Kakao API 호출 실패: status={}, body={}", status, json);
+				throw new GlobalException(HubErrorCode.KAKAO_API_ERROR);
+			}
+
+			// 좌표 파싱
+			if (!json.contains("\"x\":\"") || !json.contains("\"y\":\"")) {
+				log.warn("주소 검색 결과 없음: address={}", address);
+				throw new GlobalException(HubErrorCode.GEOCODING_FAILED);
+			}
+
+			String longitude = json.split("\"x\":\"")[1].split("\"")[0];
+			String latitude = json.split("\"y\":\"")[1].split("\"")[0];
+
+			Double lat = Double.parseDouble(latitude);
+			Double lon = Double.parseDouble(longitude);
+
+			log.info("Geocoding 성공: address={}, lat={}, lon={}", address, lat, lon);
+
+			return new Double[] {lat, lon};
+
+		} catch (GlobalException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Kakao API 호출 중 예외 발생: {}", e.getMessage(), e);
+			throw new GlobalException(HubErrorCode.KAKAO_API_ERROR);
+		}
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/client/dto/KakaoGeocodingResponse.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/client/dto/KakaoGeocodingResponse.java
@@ -1,0 +1,25 @@
+package com.hubEleven.hub.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoGeocodingResponse(List<Document> documents, Meta meta) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Document(
+			@JsonProperty("address_name") String addressName,
+			@JsonProperty("x") String longitude,
+			@JsonProperty("y") String latitude) {}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Meta(@JsonProperty("total_count") int totalCount) {}
+
+	public boolean hasResult() {
+		return documents != null && !documents.isEmpty();
+	}
+
+	public Document getFirstDocument() {
+		return documents.get(0);
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/KakaoApiProperties.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/KakaoApiProperties.java
@@ -1,0 +1,15 @@
+package com.hubEleven.hub.infrastructure.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakao.api")
+public class KakaoApiProperties {
+	private String key;
+	private String baseUrl;
+}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
@@ -1,5 +1,7 @@
 package com.hubEleven.hub.presentation;
 
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;
@@ -14,6 +16,8 @@ import com.hubEleven.hub.presentation.dto.response.HubResponseDto;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,45 +29,48 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/hubs")
+@RequiredArgsConstructor
 public class HubController {
 
 	private final HubService hubService;
 
-	public HubController(HubService hubService) {
-		this.hubService = hubService;
-	}
-
 	@PostMapping
-	public HubResponseDto createHub(@Valid @RequestBody HubCreateRequestDto request) {
+	public ResponseEntity<ApiResponse<HubResponseDto>> createHub(
+			@Valid @RequestBody HubCreateRequestDto request) {
 		CreateHubCommand command = request.toCommand();
 		HubResult result = hubService.createHub(command);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@PatchMapping("/{hubId}")
-	public HubResponseDto updateHub(
+	public ResponseEntity<ApiResponse<HubResponseDto>> updateHub(
 			@PathVariable UUID hubId, @Valid @RequestBody HubUpdateRequestDto request) {
 		UpdateHubCommand command = request.toCommand(hubId);
 		HubResult result = hubService.updateHub(command);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@DeleteMapping("/{hubId}")
-	public HubDeleteResponseDto deleteHub(@PathVariable UUID hubId) {
+	public ResponseEntity<ApiResponse<HubDeleteResponseDto>> deleteHub(@PathVariable UUID hubId) {
 		hubService.deleteHub(new DeleteHubCommand(hubId));
-		return new HubDeleteResponseDto(hubId, true);
+		HubDeleteResponseDto response = new HubDeleteResponseDto(hubId, true);
+		return ApiResponseEntity.success(response);
 	}
 
 	@GetMapping("/{hubId}")
-	public HubResponseDto getHub(@PathVariable UUID hubId) {
+	public ResponseEntity<ApiResponse<HubResponseDto>> getHub(@PathVariable UUID hubId) {
 		HubResult result = hubService.getHub(hubId);
-		return HubResponseDto.from(result);
+		HubResponseDto response = HubResponseDto.from(result);
+		return ApiResponseEntity.success(response);
 	}
 
 	@GetMapping
-	public HubListResponseDto getHubs() {
+	public ResponseEntity<ApiResponse<HubListResponseDto>> getHubs() {
 		HubListResult result = hubService.getHubs();
 		List<HubResponseDto> responses = HubResponseDto.fromList(result.hubs());
-		return new HubListResponseDto(responses);
+		HubListResponseDto response = new HubListResponseDto(responses);
+		return ApiResponseEntity.success(response);
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/HubController.java
@@ -1,7 +1,7 @@
 package com.hubEleven.hub.presentation;
 
-import com.hubEleven.common.response.ApiResponse;
-import com.hubEleven.common.response.ApiResponseEntity;
+import com.commonLib.common.response.ApiResponse;
+import com.commonLib.common.response.ApiResponseEntity;
 import com.hubEleven.hub.application.command.CreateHubCommand;
 import com.hubEleven.hub.application.command.DeleteHubCommand;
 import com.hubEleven.hub.application.command.UpdateHubCommand;

--- a/hub/src/main/java/com/hubEleven/hub/presentation/dto/request/HubCreateRequestDto.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/dto/request/HubCreateRequestDto.java
@@ -4,7 +4,6 @@ import com.hubEleven.hub.application.command.CreateHubCommand;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record HubCreateRequestDto(
@@ -12,12 +11,9 @@ public record HubCreateRequestDto(
 				String name,
 		@NotBlank(message = "주소는 필수 입력 항목입니다.") @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
 				String address,
-		@NotNull(message = "위도는 필수 입력 항목입니다.")
-				@Min(value = -90, message = "위도는 -90 이상이어야 합니다.")
-				@Max(value = 90, message = "위도는 90 이하여야 합니다.")
+		@Min(value = -90, message = "위도는 -90 이상이어야 합니다.") @Max(value = 90, message = "위도는 90 이하여야 합니다.")
 				Double latitude,
-		@NotNull(message = "경도는 필수 입력 항목입니다.")
-				@Min(value = -180, message = "경도는 -180 이상이어야 합니다.")
+		@Min(value = -180, message = "경도는 -180 이상이어야 합니다.")
 				@Max(value = 180, message = "경도는 180 이하여야 합니다.")
 				Double longitude,
 		@NotBlank(message = "지역 코드는 필수 입력 항목입니다.") @Size(max = 50, message = "지역 코드는 50자 이하여야 합니다.")

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -9,4 +9,7 @@ spring:
         enabled: true
         service-id: config
 
-
+kakao:
+  api:
+    key: ${KAKAO_REST_API_KEY}
+    base-url: https://dapi.kakao.com


### PR DESCRIPTION
### #️⃣연관된 이슈
#39 

### 🪄작업 내용  
- HubServiceImpl에 허브 이름 중복 검증 메서드 분리(validateDuplicateName) 및 GlobalException + HubErrorCode 기반 예외 처리 적용  
- 허브 생성/수정 시 위도·경도 미입력 경우 Kakao Local API를 통해 주소 기반 좌표 자동 조회하도록 변경 (KakaoApiClient, KakaoApiProperties 추가)  
- HubController에 ApiResponseEntity.success() 적용하여 공통 응답 포맷으로 통일  
- gateway application.yml에서 /v1/hubs/**, /v1/hub-routes/** 라우팅을 각각 별도 route id로 분리  
- hub 모듈 버전 0.0.2-SNAPSHOT으로 업데이트 및 Kakao API 설정(application.yml) 추가  

### ✏️리뷰 요청
- 공통 응답 잘 적용이 되었을까요?