### PR TITLE
[feat] 재고(stock) 도메인 기능 구현

### DIFF
--- a/config/src/main/resources/config-repo/product-service.yml
+++ b/config/src/main/resources/config-repo/product-service.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/product/src/main/java/com/hubEleven/product/domain/exception/ProductErrorCode.java
+++ b/product/src/main/java/com/hubEleven/product/domain/exception/ProductErrorCode.java
@@ -12,7 +12,7 @@ public enum ProductErrorCode implements StatusCode {
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
 	HUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 허브입니다."),
-    PRODUCT_DELETED(HttpStatus.BAD_REQUEST, "삭제된 상품입니다.");
+	PRODUCT_DELETED(HttpStatus.BAD_REQUEST, "삭제된 상품입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/product/src/main/java/com/hubEleven/product/domain/exception/ProductErrorCode.java
+++ b/product/src/main/java/com/hubEleven/product/domain/exception/ProductErrorCode.java
@@ -11,7 +11,8 @@ public enum ProductErrorCode implements StatusCode {
 	PRODUCT_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 존재하는 상품입니다."),
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
-	HUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 허브입니다.");
+	HUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 허브입니다."),
+    PRODUCT_DELETED(HttpStatus.BAD_REQUEST, "삭제된 상품입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
+++ b/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
@@ -1,0 +1,23 @@
+package com.hubEleven.stock.application.dto;
+
+import com.hubEleven.stock.domain.model.Stock;
+import java.util.UUID;
+
+// Service 계층의 반환용 DTO (Domain 엔티티와 API 응답 사이의 중간 계층)
+public record StockResult(
+		UUID stockId,
+		UUID productId,
+		String productName,
+		UUID hubId,
+		UUID companyId,
+		Integer quantity) {
+	public static StockResult from(Stock stock, String productName) {
+		return new StockResult(
+				stock.getStockId(),
+				stock.getProductId(),
+				productName, // productName 포함
+				stock.getHubId(),
+				stock.getCompanyId(),
+				stock.getQuantity());
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -1,0 +1,10 @@
+package com.hubEleven.stock.application.service;
+
+import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.presentation.dto.request.StockRequests.Create;
+import jakarta.validation.Valid;
+
+public interface StockService {
+
+	StockResult create(@Valid Create request);
+}

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -3,8 +3,11 @@ package com.hubEleven.stock.application.service;
 import com.hubEleven.stock.application.dto.StockResult;
 import com.hubEleven.stock.presentation.dto.request.StockRequests.Create;
 import jakarta.validation.Valid;
+import java.util.UUID;
 
 public interface StockService {
 
 	StockResult create(@Valid Create request);
+
+    StockResult getStockByProductId(UUID productId);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -9,5 +9,5 @@ public interface StockService {
 
 	StockResult create(@Valid Create request);
 
-    StockResult getStockByProductId(UUID productId);
+	StockResult getStockByProductId(UUID productId);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -1,6 +1,8 @@
 package com.hubEleven.stock.application.service;
 
+import static com.hubEleven.product.domain.exception.ProductErrorCode.PRODUCT_DELETED;
 import static com.hubEleven.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
+import static com.hubEleven.stock.domain.exception.StockErrorCode.STOCK_NOT_FOUND;
 
 import com.hubEleven.common.exception.GlobalException;
 import com.hubEleven.product.domain.model.Product;
@@ -9,6 +11,7 @@ import com.hubEleven.stock.application.dto.StockResult;
 import com.hubEleven.stock.domain.model.Stock;
 import com.hubEleven.stock.domain.repository.StockRepository;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,4 +39,24 @@ public class StockServiceImpl implements StockService {
 
 		return StockResult.from(savedStock, product.getName());
 	}
+
+    @Override
+    @Transactional(readOnly = true)
+    public StockResult getStockByProductId(UUID productId) {
+
+        // 상품 존재 여부 확인
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+
+        // 삭제된 상품인지 확인
+        if (product.isDeleted()) {
+            throw new GlobalException(PRODUCT_DELETED);
+        }
+
+        // 재고 조회
+        Stock stock = stockRepository.findByProductId(productId)
+                .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+
+        return StockResult.from(stock, product.getName());
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -1,0 +1,39 @@
+package com.hubEleven.stock.application.service;
+
+import static com.hubEleven.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
+
+import com.hubEleven.common.exception.GlobalException;
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.product.domain.repository.ProductRepository;
+import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.domain.repository.StockRepository;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StockServiceImpl implements StockService {
+
+	private final StockRepository stockRepository;
+	private final ProductRepository productRepository;
+
+	@Override
+	@Transactional
+	public StockResult create(StockRequests.Create request) {
+		// 상품 존재 여부 확인
+		Product product =
+				productRepository
+						.findById(request.productId())
+						.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+
+		Stock stock =
+				Stock.create(request.quantity(), request.productId(), request.companyId(), request.hubId());
+
+		Stock savedStock = stockRepository.save(stock);
+
+		return StockResult.from(savedStock, product.getName());
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -40,23 +40,27 @@ public class StockServiceImpl implements StockService {
 		return StockResult.from(savedStock, product.getName());
 	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public StockResult getStockByProductId(UUID productId) {
+	@Override
+	@Transactional(readOnly = true)
+	public StockResult getStockByProductId(UUID productId) {
 
-        // 상품 존재 여부 확인
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+		// 상품 존재 여부 확인
+		Product product =
+				productRepository
+						.findById(productId)
+						.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
 
-        // 삭제된 상품인지 확인
-        if (product.isDeleted()) {
-            throw new GlobalException(PRODUCT_DELETED);
-        }
+		// 삭제된 상품인지 확인
+		if (product.isDeleted()) {
+			throw new GlobalException(PRODUCT_DELETED);
+		}
 
-        // 재고 조회
-        Stock stock = stockRepository.findByProductId(productId)
-                .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+		// 재고 조회
+		Stock stock =
+				stockRepository
+						.findByProductId(productId)
+						.orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
 
-        return StockResult.from(stock, product.getName());
-    }
+		return StockResult.from(stock, product.getName());
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
@@ -8,14 +8,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum StockErrorCode implements StatusCode {
-    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "재고를 찾을 수 없습니다."),
-    INVALID_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "재고 수량이 유효하지 않습니다.");
+	STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "재고를 찾을 수 없습니다."),
+	INVALID_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "재고 수량이 유효하지 않습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    @Override
-    public String getName() {
-        return name();
-    }
+	@Override
+	public String getName() {
+		return name();
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
@@ -1,0 +1,21 @@
+package com.hubEleven.stock.domain.exception;
+
+import com.hubEleven.common.code.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockErrorCode implements StatusCode {
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "재고를 찾을 수 없습니다."),
+    INVALID_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "재고 수량이 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
@@ -1,0 +1,55 @@
+package com.hubEleven.stock.domain.model;
+
+import com.hubEleven.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_stock")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "stock_id", nullable = false)
+	private UUID stockId;
+
+	@Column(name = "product_id", nullable = false)
+	private UUID productId;
+
+	@Column(name = "hub_id", nullable = false)
+	private UUID hubId;
+
+	@Column(name = "company_id", nullable = false)
+	private UUID companyId;
+
+	@Column(name = "quantity", nullable = false)
+	private Integer quantity;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private Stock(Integer quantity, UUID productId, UUID companyId, UUID hubId) {
+		this.quantity = quantity;
+		this.productId = productId;
+		this.companyId = companyId;
+		this.hubId = hubId;
+	}
+
+	public static Stock create(Integer quantity, UUID productId, UUID companyId, UUID hubId) {
+		return Stock.builder()
+				.quantity(quantity)
+				.productId(productId)
+				.companyId(companyId)
+				.hubId(hubId)
+				.build();
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
@@ -8,5 +8,5 @@ public interface StockRepository {
 
 	Stock save(Stock stock);
 
-    Optional<Stock> findByProductId(UUID productId);
+	Optional<Stock> findByProductId(UUID productId);
 }

--- a/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
@@ -1,8 +1,12 @@
 package com.hubEleven.stock.domain.repository;
 
 import com.hubEleven.stock.domain.model.Stock;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface StockRepository {
 
 	Stock save(Stock stock);
+
+    Optional<Stock> findByProductId(UUID productId);
 }

--- a/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/repository/StockRepository.java
@@ -1,0 +1,8 @@
+package com.hubEleven.stock.domain.repository;
+
+import com.hubEleven.stock.domain.model.Stock;
+
+public interface StockRepository {
+
+	Stock save(Stock stock);
+}

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
 
-    Optional<Stock> findByProductId(UUID productId);
+	Optional<Stock> findByProductId(UUID productId);
 }

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
@@ -1,0 +1,7 @@
+package com.hubEleven.stock.infrastructure.repository;
+
+import com.hubEleven.stock.domain.model.Stock;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaStockRepository extends JpaRepository<Stock, UUID> {}

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/JpaStockRepository.java
@@ -1,7 +1,11 @@
 package com.hubEleven.stock.infrastructure.repository;
 
 import com.hubEleven.stock.domain.model.Stock;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaStockRepository extends JpaRepository<Stock, UUID> {}
+public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
+
+    Optional<Stock> findByProductId(UUID productId);
+}

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
@@ -18,8 +18,8 @@ public class StockRepositoryAdapter implements StockRepository {
 		return jpaStockRepository.save(stock);
 	}
 
-    @Override
-    public Optional<Stock> findByProductId(UUID productId) {
-        return jpaStockRepository.findByProductId(productId);
-    }
+	@Override
+	public Optional<Stock> findByProductId(UUID productId) {
+		return jpaStockRepository.findByProductId(productId);
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.hubEleven.stock.infrastructure.repository;
+
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.domain.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StockRepositoryAdapter implements StockRepository {
+
+	private final JpaStockRepository jpaStockRepository;
+
+	@Override
+	public Stock save(Stock stock) {
+		return jpaStockRepository.save(stock);
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/repository/StockRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.hubEleven.stock.infrastructure.repository;
 
 import com.hubEleven.stock.domain.model.Stock;
 import com.hubEleven.stock.domain.repository.StockRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,9 @@ public class StockRepositoryAdapter implements StockRepository {
 	public Stock save(Stock stock) {
 		return jpaStockRepository.save(stock);
 	}
+
+    @Override
+    public Optional<Stock> findByProductId(UUID productId) {
+        return jpaStockRepository.findByProductId(productId);
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -1,0 +1,33 @@
+package com.hubEleven.stock.presentation.controller;
+
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
+import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.application.service.StockService;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import com.hubEleven.stock.presentation.dto.response.StockResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// TODO @AuthenticationPrincipal 권한로직
+@RestController
+@RequestMapping("/v1/stocks")
+@RequiredArgsConstructor
+public class StockController {
+
+	private final StockService stockService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<StockResponse>> create(
+			@Valid @RequestBody StockRequests.Create request) {
+
+		StockResult result = stockService.create(request);
+
+		return ApiResponseEntity.success(StockResponse.from(result));
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -7,8 +7,11 @@ import com.hubEleven.stock.application.service.StockService;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
 import com.hubEleven.stock.presentation.dto.response.StockResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,4 +33,13 @@ public class StockController {
 
 		return ApiResponseEntity.success(StockResponse.from(result));
 	}
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ApiResponse<StockResponse>> getStock(
+            @PathVariable UUID productId) {
+
+        StockResult result = stockService.getStockByProductId(productId);
+
+        return ApiResponseEntity.success(StockResponse.from(result));
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -34,12 +34,11 @@ public class StockController {
 		return ApiResponseEntity.success(StockResponse.from(result));
 	}
 
-    @GetMapping("/{productId}")
-    public ResponseEntity<ApiResponse<StockResponse>> getStock(
-            @PathVariable UUID productId) {
+	@GetMapping("/{productId}")
+	public ResponseEntity<ApiResponse<StockResponse>> getStock(@PathVariable UUID productId) {
 
-        StockResult result = stockService.getStockByProductId(productId);
+		StockResult result = stockService.getStockByProductId(productId);
 
-        return ApiResponseEntity.success(StockResponse.from(result));
-    }
+		return ApiResponseEntity.success(StockResponse.from(result));
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -1,0 +1,15 @@
+package com.hubEleven.stock.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public class StockRequests {
+
+	public record Create(
+			@NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+					Integer quantity,
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
+			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
+}

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
@@ -1,0 +1,23 @@
+package com.hubEleven.stock.presentation.dto.response;
+
+import com.hubEleven.stock.application.dto.StockResult;
+import java.util.UUID;
+
+public record StockResponse(
+		UUID stockId,
+		UUID productId,
+		String productName,
+		UUID hubId,
+		UUID companyId,
+		Integer quantity) {
+
+	public static StockResponse from(StockResult stockResult) {
+		return new StockResponse(
+				stockResult.stockId(),
+				stockResult.productId(),
+				stockResult.productName(),
+				stockResult.hubId(),
+				stockResult.companyId(),
+				stockResult.quantity());
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#35 

### 🪄작업 내용 
- 상품 등록 시 수량 등록
- 특정 상품의 재고 조회

### ✏️Additional Notes
- 상품(product)와 재고(stock) API 분리로 인해 재고(stock) 도메인의 CRUD 기능 추가되었습니다.
-> 필수 기능 사항 우선순위로 구현 후 추후 구현 예정
