### PR TITLE
[feat] 주문(order) 도메인 기능 구현

### DIFF
--- a/config/src/main/resources/config-repo/order-service.yml
+++ b/config/src/main/resources/config-repo/order-service.yml
@@ -1,0 +1,20 @@
+spring:
+  application:
+    name: order-service
+  datasource:
+    url: jdbc:mysql://localhost:3306/hubeleven?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+server:
+  port: 0

--- a/order/src/main/java/com/hubEleven/order/OrderApplication.java
+++ b/order/src/main/java/com/hubEleven/order/OrderApplication.java
@@ -3,9 +3,11 @@ package com.hubEleven.order;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableJpaAuditing
 public class OrderApplication {
 
 	public static void main(String[] args) {

--- a/order/src/main/java/com/hubEleven/order/OrderApplication.java
+++ b/order/src/main/java/com/hubEleven/order/OrderApplication.java
@@ -2,8 +2,10 @@ package com.hubEleven.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OrderApplication {
 
 	public static void main(String[] args) {

--- a/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
+++ b/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
@@ -8,18 +8,16 @@ public record OrderResult(
         UUID requestorCompanyId,
         UUID recipientCompanyId,
         UUID productId,
-        String productName,
         UUID deliveryId,
         Long quantity,
         String note) {
 
-    public static OrderResult from(Order order, String productName) {
+    public static OrderResult from(Order order) {
         return new OrderResult(
                 order.getOrderId(),
                 order.getRequestorCompanyId(),
                 order.getRecipientCompanyId(),
                 order.getProductId(),
-                productName,
                 order.getDeliveryId(),
                 order.getQuantity(),
                 order.getNote());

--- a/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
+++ b/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
@@ -1,0 +1,27 @@
+package com.hubEleven.order.application.dto;
+
+import com.hubEleven.order.domain.model.Order;
+import java.util.UUID;
+
+public record OrderResult(
+        UUID oderId,
+        UUID requestorCompanyId,
+        UUID recipientCompanyId,
+        UUID productId,
+        String productName,
+        UUID deliveryId,
+        Long quantity,
+        String note) {
+
+    public static OrderResult from(Order order, String productName) {
+        return new OrderResult(
+                order.getOrderId(),
+                order.getRequestorCompanyId(),
+                order.getRecipientCompanyId(),
+                order.getProductId(),
+                productName,
+                order.getDeliveryId(),
+                order.getQuantity(),
+                order.getNote());
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
+++ b/order/src/main/java/com/hubEleven/order/application/dto/OrderResult.java
@@ -4,22 +4,22 @@ import com.hubEleven.order.domain.model.Order;
 import java.util.UUID;
 
 public record OrderResult(
-        UUID oderId,
-        UUID requestorCompanyId,
-        UUID recipientCompanyId,
-        UUID productId,
-        UUID deliveryId,
-        Long quantity,
-        String note) {
+		UUID oderId,
+		UUID requestorCompanyId,
+		UUID recipientCompanyId,
+		UUID productId,
+		UUID deliveryId,
+		Long quantity,
+		String note) {
 
-    public static OrderResult from(Order order) {
-        return new OrderResult(
-                order.getOrderId(),
-                order.getRequestorCompanyId(),
-                order.getRecipientCompanyId(),
-                order.getProductId(),
-                order.getDeliveryId(),
-                order.getQuantity(),
-                order.getNote());
-    }
+	public static OrderResult from(Order order) {
+		return new OrderResult(
+				order.getOrderId(),
+				order.getRequestorCompanyId(),
+				order.getRecipientCompanyId(),
+				order.getProductId(),
+				order.getDeliveryId(),
+				order.getQuantity(),
+				order.getNote());
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -15,4 +15,6 @@ public interface OrderService {
     OrderResult getOrderDetail(UUID orderId);
 
     OrderResult updateOrder(UUID orderId, OrderRequests.Update request);
+
+    void deleteOrder(UUID orderId, Long userId);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -4,6 +4,7 @@ import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.request.OrderRequests.Create;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,4 +13,6 @@ public interface OrderService {
     OrderResult create(OrderRequests.Create request);
 
     Page<OrderResult> searchOrders(String keyword, Pageable pageable);
+
+    OrderResult getOrderDetail(UUID orderId);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -17,4 +17,6 @@ public interface OrderService {
     OrderResult updateOrder(UUID orderId, OrderRequests.Update request);
 
     void deleteOrder(UUID orderId, Long userId);
+
+    void cancelOrder(UUID orderId, Long userId);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -2,8 +2,6 @@ package com.hubEleven.order.application.service;
 
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
-import com.hubEleven.order.presentation.dto.request.OrderRequests.Create;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,4 +13,6 @@ public interface OrderService {
     Page<OrderResult> searchOrders(String keyword, Pageable pageable);
 
     OrderResult getOrderDetail(UUID orderId);
+
+    OrderResult updateOrder(UUID orderId, OrderRequests.Update request);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -8,15 +8,15 @@ import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
-    OrderResult create(OrderRequests.Create request);
+	OrderResult create(OrderRequests.Create request);
 
-    Page<OrderResult> searchOrders(String keyword, Pageable pageable);
+	Page<OrderResult> searchOrders(String keyword, Pageable pageable);
 
-    OrderResult getOrderDetail(UUID orderId);
+	OrderResult getOrderDetail(UUID orderId);
 
-    OrderResult updateOrder(UUID orderId, OrderRequests.Update request);
+	OrderResult updateOrder(UUID orderId, OrderRequests.Update request);
 
-    void deleteOrder(UUID orderId, Long userId);
+	void deleteOrder(UUID orderId, Long userId);
 
-    void cancelOrder(UUID orderId, Long userId);
+	void cancelOrder(UUID orderId, Long userId);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -1,0 +1,11 @@
+package com.hubEleven.order.application.service;
+
+import com.hubEleven.order.application.dto.OrderResult;
+import com.hubEleven.order.presentation.dto.request.OrderRequests;
+import com.hubEleven.order.presentation.dto.request.OrderRequests.Create;
+import jakarta.validation.Valid;
+
+public interface OrderService {
+
+    OrderResult create(OrderRequests.Create request);
+}

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderService.java
@@ -4,8 +4,12 @@ import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.request.OrderRequests.Create;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
     OrderResult create(OrderRequests.Create request);
+
+    Page<OrderResult> searchOrders(String keyword, Pageable pageable);
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.hubEleven.order.application.service;
 
+import static com.hubEleven.order.domain.exception.OrderErrorCode.ORDER_NOT_FOUND;
 import static com.hubEleven.order.domain.exception.OrderErrorCode.PRODUCT_NOT_FOUND;
 import static com.hubEleven.order.domain.exception.OrderErrorCode.RECIPIENT_COMPANY_NOT_FOUND;
 import static com.hubEleven.order.domain.exception.OrderErrorCode.REQUESTOR_COMPANY_NOT_FOUND;
@@ -14,6 +15,7 @@ import com.hubEleven.order.infrastructure.client.ProductFeignClient;
 import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductResponse;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import feign.FeignException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -85,4 +87,16 @@ public class OrderServiceImpl implements OrderService {
 
         return orders.map(OrderResult::from);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderResult getOrderDetail(UUID orderId) {
+
+        Order order = orderRepository
+                .findById(orderId)
+                .orElseThrow(() -> new GlobalException(ORDER_NOT_FOUND));
+
+        return OrderResult.from(order);
+    }
+
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -4,6 +4,7 @@ import static com.hubEleven.order.domain.exception.OrderErrorCode.ORDER_NOT_FOUN
 import static com.hubEleven.order.domain.exception.OrderErrorCode.PRODUCT_NOT_FOUND;
 import static com.hubEleven.order.domain.exception.OrderErrorCode.RECIPIENT_COMPANY_NOT_FOUND;
 import static com.hubEleven.order.domain.exception.OrderErrorCode.REQUESTOR_COMPANY_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.STOCK_RESTORE_FAILED;
 
 import com.hubEleven.common.exception.GlobalException;
 import com.hubEleven.order.application.dto.OrderResult;
@@ -13,6 +14,7 @@ import com.hubEleven.order.infrastructure.client.CompanyFeignClient;
 import com.hubEleven.order.infrastructure.client.CompanyFeignClient.CompanyResponse;
 import com.hubEleven.order.infrastructure.client.ProductFeignClient;
 import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductResponse;
+import com.hubEleven.order.infrastructure.client.StockFeignClient;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import feign.FeignException;
 import java.util.UUID;
@@ -29,6 +31,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
     private final ProductFeignClient productFeignClient;
     private final CompanyFeignClient companyFeignClient;
+    private final StockFeignClient stockFeignClient;
 
 
     // 주문 존재 여부 확인 메서드
@@ -123,6 +126,29 @@ public class OrderServiceImpl implements OrderService {
         Order order = validateOrderExists(orderId);
 
         // 논리 삭제 처리
+        order.delete(userId);
+    }
+
+    @Override
+    @Transactional
+    public void cancelOrder(UUID orderId, Long userId) {
+
+        Order order = validateOrderExists(orderId);
+
+        // 재고 복원 처리
+        try {
+            StockFeignClient.StockRestoreRequest request =
+                    new StockFeignClient.StockRestoreRequest(
+                            order.getProductId(),
+                            order.getQuantity()
+                    );
+            stockFeignClient.restoreStock(request);
+
+        } catch (FeignException e) {
+            throw new GlobalException(STOCK_RESTORE_FAILED);
+        }
+
+        // 취소건도 delete_at 필드에 기록
         order.delete(userId);
     }
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -30,6 +30,14 @@ public class OrderServiceImpl implements OrderService {
     private final ProductFeignClient productFeignClient;
     private final CompanyFeignClient companyFeignClient;
 
+
+    // 주문 존재 여부 확인 메서드
+    private Order validateOrderExists(UUID orderId) {
+        return orderRepository
+                .findById(orderId)
+                .orElseThrow(() -> new GlobalException(ORDER_NOT_FOUND));
+    }
+
     @Override
     @Transactional
     public OrderResult create(OrderRequests.Create request) {
@@ -92,11 +100,19 @@ public class OrderServiceImpl implements OrderService {
     @Transactional(readOnly = true)
     public OrderResult getOrderDetail(UUID orderId) {
 
-        Order order = orderRepository
-                .findById(orderId)
-                .orElseThrow(() -> new GlobalException(ORDER_NOT_FOUND));
+        Order order = validateOrderExists(orderId);
 
         return OrderResult.from(order);
     }
 
+    @Override
+    @Transactional
+    public OrderResult updateOrder(UUID productId, OrderRequests.Update request) {
+
+        Order order = validateOrderExists(productId);
+
+        order.update(request.quantity(), request.note());
+
+        return OrderResult.from(orderRepository.save(order));
+    }
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -1,5 +1,11 @@
 package com.hubEleven.order.application.service;
 
+import static com.hubEleven.order.domain.exception.OrderErrorCode.ORDER_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.PRODUCT_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.RECIPIENT_COMPANY_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.REQUESTOR_COMPANY_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.STOCK_RESTORE_FAILED;
+
 import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.domain.exception.OrderErrorCode;

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -29,141 +29,134 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
-    private final OrderRepository orderRepository;
-    private final ProductFeignClient productFeignClient;
-    private final CompanyFeignClient companyFeignClient;
-    private final StockFeignClient stockFeignClient;
+	private final OrderRepository orderRepository;
+	private final ProductFeignClient productFeignClient;
+	private final CompanyFeignClient companyFeignClient;
+	private final StockFeignClient stockFeignClient;
 
+	// 주문 존재 여부 확인 메서드
+	private Order validateOrderExists(UUID orderId) {
+		return orderRepository
+				.findById(orderId)
+				.orElseThrow(() -> new GlobalException(ORDER_NOT_FOUND));
+	}
 
-    // 주문 존재 여부 확인 메서드
-    private Order validateOrderExists(UUID orderId) {
-        return orderRepository
-                .findById(orderId)
-                .orElseThrow(() -> new GlobalException(ORDER_NOT_FOUND));
-    }
+	@Override
+	@Transactional
+	public OrderResult create(OrderRequests.Create request) {
 
-    @Override
-    @Transactional
-    public OrderResult create(OrderRequests.Create request) {
+		// 요청 업체 존재 여부 확인
+		try {
+			CompanyResponse company = companyFeignClient.getCompany(request.requestorCompanyId());
+			if (company == null) {
+				throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
+			}
+		} catch (FeignException.NotFound e) {
+			throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
+		}
 
-        // 요청 업체 존재 여부 확인
-        try {
-            CompanyResponse company = companyFeignClient.getCompany(request.requestorCompanyId());
-            if (company == null) {
-                throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
-            }
-        } catch (FeignException.NotFound e) {
-            throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
-        }
+		// 수령 업체 존재 여부 확인
+		try {
+			CompanyResponse company = companyFeignClient.getCompany(request.recipientCompanyId());
+			if (company == null) {
+				throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
+			}
+		} catch (FeignException.NotFound e) {
+			throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
+		}
 
-        // 수령 업체 존재 여부 확인
-        try {
-            CompanyResponse company = companyFeignClient.getCompany(request.recipientCompanyId());
-            if (company == null) {
-                throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
-            }
-        } catch (FeignException.NotFound e) {
-            throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
-        }
+		// 상품 존재 여부 확인
+		try {
+			ProductResponse product = productFeignClient.getProduct(request.productId());
+			if (product == null) {
+				throw new GlobalException(PRODUCT_NOT_FOUND);
+			}
+		} catch (FeignException.NotFound e) {
+			throw new GlobalException(PRODUCT_NOT_FOUND);
+		}
 
-        // 상품 존재 여부 확인
-        try {
-            ProductResponse product = productFeignClient.getProduct(request.productId());
-            if (product == null) {
-                throw new GlobalException(PRODUCT_NOT_FOUND);
-            }
-        } catch (FeignException.NotFound e) {
-            throw new GlobalException(PRODUCT_NOT_FOUND);
-        }
+		// 재고 차감
+		try {
+			StockFeignClient.StockDecreaseRequest stockRequest =
+					new StockFeignClient.StockDecreaseRequest(request.productId(), request.quantity());
+			stockFeignClient.decreaseStock(stockRequest);
 
-        // 재고 차감
-        try {
-            StockFeignClient.StockDecreaseRequest stockRequest =
-                    new StockFeignClient.StockDecreaseRequest(
-                            request.productId(),
-                            request.quantity()
-                    );
-            stockFeignClient.decreaseStock(stockRequest);
+		} catch (FeignException e) {
+			// 재고 부족 or Stock 서비스 오류
+			throw new GlobalException(OrderErrorCode.STOCK_INSUFFICIENT);
+		}
 
-        } catch (FeignException e) {
-            // 재고 부족 or Stock 서비스 오류
-            throw new GlobalException(OrderErrorCode.STOCK_INSUFFICIENT);
-        }
+		// 주문 생성 및 저장
+		Order order =
+				Order.create(
+						request.requestorCompanyId(),
+						request.recipientCompanyId(),
+						request.productId(),
+						request.deliveryId(),
+						request.quantity(),
+						request.note());
 
-        // 주문 생성 및 저장
-        Order order = Order.create(
-                request.requestorCompanyId(),
-                request.recipientCompanyId(),
-                request.productId(),
-                request.deliveryId(),
-                request.quantity(),
-                request.note());
+		Order savedOrder = orderRepository.save(order);
 
-        Order savedOrder = orderRepository.save(order);
+		return OrderResult.from(savedOrder);
+	}
 
-        return OrderResult.from(savedOrder);
+	@Override
+	@Transactional(readOnly = true)
+	public Page<OrderResult> searchOrders(String keyword, Pageable pageable) {
 
-    }
+		Page<Order> orders = orderRepository.searchOrders(keyword, pageable);
 
-    @Override
-    @Transactional(readOnly = true)
-    public Page<OrderResult> searchOrders(String keyword, Pageable pageable) {
+		return orders.map(OrderResult::from);
+	}
 
-        Page<Order> orders = orderRepository.searchOrders(keyword, pageable);
+	@Override
+	@Transactional(readOnly = true)
+	public OrderResult getOrderDetail(UUID orderId) {
 
-        return orders.map(OrderResult::from);
-    }
+		Order order = validateOrderExists(orderId);
 
-    @Override
-    @Transactional(readOnly = true)
-    public OrderResult getOrderDetail(UUID orderId) {
+		return OrderResult.from(order);
+	}
 
-        Order order = validateOrderExists(orderId);
+	@Override
+	@Transactional
+	public OrderResult updateOrder(UUID orderId, OrderRequests.Update request) {
 
-        return OrderResult.from(order);
-    }
+		Order order = validateOrderExists(orderId);
 
-    @Override
-    @Transactional
-    public OrderResult updateOrder(UUID orderId, OrderRequests.Update request) {
+		order.update(request.quantity(), request.note());
 
-        Order order = validateOrderExists(orderId);
+		return OrderResult.from(orderRepository.save(order));
+	}
 
-        order.update(request.quantity(), request.note());
+	@Override
+	@Transactional
+	public void deleteOrder(UUID orderId, Long userId) {
 
-        return OrderResult.from(orderRepository.save(order));
-    }
+		Order order = validateOrderExists(orderId);
 
-    @Override
-    @Transactional
-    public void deleteOrder(UUID orderId, Long userId) {
+		// 논리 삭제 처리
+		order.delete(userId);
+	}
 
-        Order order = validateOrderExists(orderId);
+	@Override
+	@Transactional
+	public void cancelOrder(UUID orderId, Long userId) {
 
-        // 논리 삭제 처리
-        order.delete(userId);
-    }
+		Order order = validateOrderExists(orderId);
 
-    @Override
-    @Transactional
-    public void cancelOrder(UUID orderId, Long userId) {
+		// 재고 복원 처리
+		try {
+			StockFeignClient.StockRestoreRequest request =
+					new StockFeignClient.StockRestoreRequest(order.getProductId(), order.getQuantity());
+			stockFeignClient.restoreStock(request);
 
-        Order order = validateOrderExists(orderId);
+		} catch (FeignException e) {
+			throw new GlobalException(STOCK_RESTORE_FAILED);
+		}
 
-        // 재고 복원 처리
-        try {
-            StockFeignClient.StockRestoreRequest request =
-                    new StockFeignClient.StockRestoreRequest(
-                            order.getProductId(),
-                            order.getQuantity()
-                    );
-            stockFeignClient.restoreStock(request);
-
-        } catch (FeignException e) {
-            throw new GlobalException(STOCK_RESTORE_FAILED);
-        }
-
-        // 취소건도 delete_at 필드에 기록
-        order.delete(userId);
-    }
+		// 취소건도 delete_at 필드에 기록
+		order.delete(userId);
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -8,6 +8,7 @@ import static com.hubEleven.order.domain.exception.OrderErrorCode.STOCK_RESTORE_
 
 import com.hubEleven.common.exception.GlobalException;
 import com.hubEleven.order.application.dto.OrderResult;
+import com.hubEleven.order.domain.exception.OrderErrorCode;
 import com.hubEleven.order.domain.model.Order;
 import com.hubEleven.order.domain.repository.OrderRepository;
 import com.hubEleven.order.infrastructure.client.CompanyFeignClient;
@@ -73,6 +74,20 @@ public class OrderServiceImpl implements OrderService {
             }
         } catch (FeignException.NotFound e) {
             throw new GlobalException(PRODUCT_NOT_FOUND);
+        }
+
+        // 재고 차감
+        try {
+            StockFeignClient.StockDecreaseRequest stockRequest =
+                    new StockFeignClient.StockDecreaseRequest(
+                            request.productId(),
+                            request.quantity()
+                    );
+            stockFeignClient.decreaseStock(stockRequest);
+
+        } catch (FeignException e) {
+            // 재고 부족 or Stock 서비스 오류
+            throw new GlobalException(OrderErrorCode.STOCK_INSUFFICIENT);
         }
 
         // 주문 생성 및 저장

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -1,0 +1,78 @@
+package com.hubEleven.order.application.service;
+
+import static com.hubEleven.order.domain.exception.OrderErrorCode.PRODUCT_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.RECIPIENT_COMPANY_NOT_FOUND;
+import static com.hubEleven.order.domain.exception.OrderErrorCode.REQUESTOR_COMPANY_NOT_FOUND;
+
+import com.hubEleven.common.exception.GlobalException;
+import com.hubEleven.order.application.dto.OrderResult;
+import com.hubEleven.order.domain.model.Order;
+import com.hubEleven.order.domain.repository.OrderRepository;
+import com.hubEleven.order.infrastructure.client.CompanyFeignClient;
+import com.hubEleven.order.infrastructure.client.CompanyFeignClient.CompanyResponse;
+import com.hubEleven.order.infrastructure.client.ProductFeignClient;
+import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductResponse;
+import com.hubEleven.order.presentation.dto.request.OrderRequests;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ProductFeignClient productFeignClient;
+    private final CompanyFeignClient companyFeignClient;
+
+    @Override
+    @Transactional
+    public OrderResult create(OrderRequests.Create request) {
+
+        // 요청 업체 존재 여부 확인
+        try {
+            CompanyResponse company = companyFeignClient.getCompany(request.requestorCompanyId());
+            if (company == null) {
+                throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
+            }
+        } catch (FeignException.NotFound e) {
+            throw new GlobalException(REQUESTOR_COMPANY_NOT_FOUND);
+        }
+
+        // 수령 업체 존재 여부 확인
+        try {
+            CompanyResponse company = companyFeignClient.getCompany(request.recipientCompanyId());
+            if (company == null) {
+                throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
+            }
+        } catch (FeignException.NotFound e) {
+            throw new GlobalException(RECIPIENT_COMPANY_NOT_FOUND);
+        }
+
+        // 상품 존재 여부 확인
+        ProductResponse product;
+        try {
+            product = productFeignClient.getProduct(request.productId());
+            if (product == null) {
+                throw new GlobalException(PRODUCT_NOT_FOUND);
+            }
+        } catch (FeignException.NotFound e) {
+            throw new GlobalException(PRODUCT_NOT_FOUND);
+        }
+
+        // 주문 생성 및 저장
+        Order order = Order.create(
+                request.requestorCompanyId(),
+                request.recipientCompanyId(),
+                request.productId(),
+                request.deliveryId(),
+                request.quantity(),
+                request.note());
+
+        Order savedOrder = orderRepository.save(order);
+
+        return OrderResult.from(savedOrder, product.name());
+
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -15,6 +15,8 @@ import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductRespo
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,9 +53,8 @@ public class OrderServiceImpl implements OrderService {
         }
 
         // 상품 존재 여부 확인
-        ProductResponse product;
         try {
-            product = productFeignClient.getProduct(request.productId());
+            ProductResponse product = productFeignClient.getProduct(request.productId());
             if (product == null) {
                 throw new GlobalException(PRODUCT_NOT_FOUND);
             }
@@ -72,7 +73,16 @@ public class OrderServiceImpl implements OrderService {
 
         Order savedOrder = orderRepository.save(order);
 
-        return OrderResult.from(savedOrder, product.name());
+        return OrderResult.from(savedOrder);
 
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<OrderResult> searchOrders(String keyword, Pageable pageable) {
+
+        Page<Order> orders = orderRepository.searchOrders(keyword, pageable);
+
+        return orders.map(OrderResult::from);
     }
 }

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -1,12 +1,6 @@
 package com.hubEleven.order.application.service;
 
-import static com.hubEleven.order.domain.exception.OrderErrorCode.ORDER_NOT_FOUND;
-import static com.hubEleven.order.domain.exception.OrderErrorCode.PRODUCT_NOT_FOUND;
-import static com.hubEleven.order.domain.exception.OrderErrorCode.RECIPIENT_COMPANY_NOT_FOUND;
-import static com.hubEleven.order.domain.exception.OrderErrorCode.REQUESTOR_COMPANY_NOT_FOUND;
-import static com.hubEleven.order.domain.exception.OrderErrorCode.STOCK_RESTORE_FAILED;
-
-import com.hubEleven.common.exception.GlobalException;
+import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.domain.exception.OrderErrorCode;
 import com.hubEleven.order.domain.model.Order;

--- a/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/hubEleven/order/application/service/OrderServiceImpl.java
@@ -107,12 +107,22 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional
-    public OrderResult updateOrder(UUID productId, OrderRequests.Update request) {
+    public OrderResult updateOrder(UUID orderId, OrderRequests.Update request) {
 
-        Order order = validateOrderExists(productId);
+        Order order = validateOrderExists(orderId);
 
         order.update(request.quantity(), request.note());
 
         return OrderResult.from(orderRepository.save(order));
+    }
+
+    @Override
+    @Transactional
+    public void deleteOrder(UUID orderId, Long userId) {
+
+        Order order = validateOrderExists(orderId);
+
+        // 논리 삭제 처리
+        order.delete(userId);
     }
 }

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -8,25 +8,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum OrderErrorCode implements StatusCode {
-    // Company
-    REQUESTOR_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
-    RECIPIENT_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+	// Company
+	REQUESTOR_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+	RECIPIENT_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
 
-    // Product
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+	// Product
+	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 
-    // Stock
-    STOCK_RESTORE_FAILED(HttpStatus.BAD_REQUEST, "재고 복구에 실패했습니다."),
-    STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+	// Stock
+	STOCK_RESTORE_FAILED(HttpStatus.BAD_REQUEST, "재고 복구에 실패했습니다."),
+	STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
 
-    // Order
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");
+	// Order
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    @Override
-    public String getName() {
-        return name();
-    }
+	@Override
+	public String getName() {
+		return name();
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -1,6 +1,6 @@
 package com.hubEleven.order.domain.exception;
 
-import com.hubEleven.common.code.StatusCode;
+import com.commonLib.common.code.StatusCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -1,0 +1,25 @@
+package com.hubEleven.order.domain.exception;
+
+import com.hubEleven.common.code.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements StatusCode {
+    // Company
+    REQUESTOR_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+    RECIPIENT_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+
+    //Product
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -17,6 +17,7 @@ public enum OrderErrorCode implements StatusCode {
 
     // Stock
     STOCK_RESTORE_FAILED(HttpStatus.BAD_REQUEST, "재고 복구에 실패했습니다."),
+    STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -13,7 +13,10 @@ public enum OrderErrorCode implements StatusCode {
     RECIPIENT_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
 
     //Product
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+
+    //Order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/hubEleven/order/domain/exception/OrderErrorCode.java
@@ -12,10 +12,13 @@ public enum OrderErrorCode implements StatusCode {
     REQUESTOR_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
     RECIPIENT_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
 
-    //Product
+    // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 
-    //Order
+    // Stock
+    STOCK_RESTORE_FAILED(HttpStatus.BAD_REQUEST, "재고 복구에 실패했습니다."),
+
+    // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/order/src/main/java/com/hubEleven/order/domain/model/Order.java
+++ b/order/src/main/java/com/hubEleven/order/domain/model/Order.java
@@ -1,0 +1,70 @@
+package com.hubEleven.order.domain.model;
+
+import com.hubEleven.common.annotation.SoftDeletable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_order")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SoftDeletable // soft delete 커스텀 어노테이션
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @Column(name = "requestor_company_id", nullable = false)
+    private UUID requestorCompanyId;
+
+    @Column(name = "recipient_company_id", nullable = false)
+    private UUID recipientCompanyId;
+
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Column(name = "delivery_id", nullable = false)
+    private UUID deliveryId;
+
+    @Min(0)
+    @Column(name = "quantity", nullable = false)
+    private Long quantity;
+
+    @Column(name = "note", length = 500)
+    private String note;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Order(UUID requestorCompanyId, UUID recipientCompanyId, UUID productId,
+                  UUID deliveryId, Long quantity, String note) {
+        this.requestorCompanyId = requestorCompanyId;
+        this.recipientCompanyId = recipientCompanyId;
+        this.productId = productId;
+        this.deliveryId = deliveryId;
+        this.quantity = quantity;
+        this.note = note;
+    }
+
+    public static Order create(UUID requestorCompanyId, UUID recipientCompanyId, UUID productId,
+                               UUID deliveryId, Long quantity, String note) {
+        return Order.builder()
+                .requestorCompanyId(requestorCompanyId)
+                .recipientCompanyId(recipientCompanyId)
+                .productId(productId)
+                .deliveryId(deliveryId)
+                .quantity(quantity)
+                .note(note)
+                .build();
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/domain/model/Order.java
+++ b/order/src/main/java/com/hubEleven/order/domain/model/Order.java
@@ -1,6 +1,7 @@
 package com.hubEleven.order.domain.model;
 
 import com.hubEleven.common.annotation.SoftDeletable;
+import com.hubEleven.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SoftDeletable // soft delete 커스텀 어노테이션
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/order/src/main/java/com/hubEleven/order/domain/model/Order.java
+++ b/order/src/main/java/com/hubEleven/order/domain/model/Order.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,7 +40,7 @@ public class Order extends BaseEntity {
     @Column(name = "delivery_id", nullable = false)
     private UUID deliveryId;
 
-    @Min(0)
+    @Min(1)
     @Column(name = "quantity", nullable = false)
     private Long quantity;
 
@@ -67,5 +68,14 @@ public class Order extends BaseEntity {
                 .quantity(quantity)
                 .note(note)
                 .build();
+    }
+
+    public void update(Long quantity, String note) {
+        if (quantity != null && quantity >= 1) {
+            this.quantity = quantity;
+        }
+        if (note != null && !note.isBlank()) {
+            this.note = note;
+        }
     }
 }

--- a/order/src/main/java/com/hubEleven/order/domain/model/Order.java
+++ b/order/src/main/java/com/hubEleven/order/domain/model/Order.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,59 +22,69 @@ import lombok.NoArgsConstructor;
 @SoftDeletable // soft delete 커스텀 어노테이션
 public class Order extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "order_id", nullable = false)
-    private UUID orderId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "order_id", nullable = false)
+	private UUID orderId;
 
-    @Column(name = "requestor_company_id", nullable = false)
-    private UUID requestorCompanyId;
+	@Column(name = "requestor_company_id", nullable = false)
+	private UUID requestorCompanyId;
 
-    @Column(name = "recipient_company_id", nullable = false)
-    private UUID recipientCompanyId;
+	@Column(name = "recipient_company_id", nullable = false)
+	private UUID recipientCompanyId;
 
-    @Column(name = "product_id", nullable = false)
-    private UUID productId;
+	@Column(name = "product_id", nullable = false)
+	private UUID productId;
 
-    @Column(name = "delivery_id", nullable = false)
-    private UUID deliveryId;
+	@Column(name = "delivery_id", nullable = false)
+	private UUID deliveryId;
 
-    @Min(1)
-    @Column(name = "quantity", nullable = false)
-    private Long quantity;
+	@Min(1)
+	@Column(name = "quantity", nullable = false)
+	private Long quantity;
 
-    @Column(name = "note", length = 500)
-    private String note;
+	@Column(name = "note", length = 500)
+	private String note;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private Order(UUID requestorCompanyId, UUID recipientCompanyId, UUID productId,
-                  UUID deliveryId, Long quantity, String note) {
-        this.requestorCompanyId = requestorCompanyId;
-        this.recipientCompanyId = recipientCompanyId;
-        this.productId = productId;
-        this.deliveryId = deliveryId;
-        this.quantity = quantity;
-        this.note = note;
-    }
+	@Builder(access = AccessLevel.PRIVATE)
+	private Order(
+			UUID requestorCompanyId,
+			UUID recipientCompanyId,
+			UUID productId,
+			UUID deliveryId,
+			Long quantity,
+			String note) {
+		this.requestorCompanyId = requestorCompanyId;
+		this.recipientCompanyId = recipientCompanyId;
+		this.productId = productId;
+		this.deliveryId = deliveryId;
+		this.quantity = quantity;
+		this.note = note;
+	}
 
-    public static Order create(UUID requestorCompanyId, UUID recipientCompanyId, UUID productId,
-                               UUID deliveryId, Long quantity, String note) {
-        return Order.builder()
-                .requestorCompanyId(requestorCompanyId)
-                .recipientCompanyId(recipientCompanyId)
-                .productId(productId)
-                .deliveryId(deliveryId)
-                .quantity(quantity)
-                .note(note)
-                .build();
-    }
+	public static Order create(
+			UUID requestorCompanyId,
+			UUID recipientCompanyId,
+			UUID productId,
+			UUID deliveryId,
+			Long quantity,
+			String note) {
+		return Order.builder()
+				.requestorCompanyId(requestorCompanyId)
+				.recipientCompanyId(recipientCompanyId)
+				.productId(productId)
+				.deliveryId(deliveryId)
+				.quantity(quantity)
+				.note(note)
+				.build();
+	}
 
-    public void update(Long quantity, String note) {
-        if (quantity != null && quantity >= 1) {
-            this.quantity = quantity;
-        }
-        if (note != null && !note.isBlank()) {
-            this.note = note;
-        }
-    }
+	public void update(Long quantity, String note) {
+		if (quantity != null && quantity >= 1) {
+			this.quantity = quantity;
+		}
+		if (note != null && !note.isBlank()) {
+			this.note = note;
+		}
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/domain/model/Order.java
+++ b/order/src/main/java/com/hubEleven/order/domain/model/Order.java
@@ -1,7 +1,7 @@
 package com.hubEleven.order.domain.model;
 
-import com.hubEleven.common.annotation.SoftDeletable;
-import com.hubEleven.common.model.BaseEntity;
+import com.commonLib.common.annotation.SoftDeletable;
+import com.commonLib.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
@@ -1,8 +1,12 @@
 package com.hubEleven.order.domain.repository;
 
 import com.hubEleven.order.domain.model.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderRepository {
 
     Order save(Order order);
+
+    Page<Order> searchOrders(String keyword, Pageable pageable);
 }

--- a/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
@@ -1,6 +1,8 @@
 package com.hubEleven.order.domain.repository;
 
 import com.hubEleven.order.domain.model.Order;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,4 +11,6 @@ public interface OrderRepository {
     Order save(Order order);
 
     Page<Order> searchOrders(String keyword, Pageable pageable);
+
+    Optional<Order> findById(UUID orderId);
 }

--- a/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.hubEleven.order.domain.repository;
+
+import com.hubEleven.order.domain.model.Order;
+
+public interface OrderRepository {
+
+    Order save(Order order);
+}

--- a/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/domain/repository/OrderRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface OrderRepository {
 
-    Order save(Order order);
+	Order save(Order order);
 
-    Page<Order> searchOrders(String keyword, Pageable pageable);
+	Page<Order> searchOrders(String keyword, Pageable pageable);
 
-    Optional<Order> findById(UUID orderId);
+	Optional<Order> findById(UUID orderId);
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/CompanyFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/CompanyFeignClient.java
@@ -1,0 +1,15 @@
+package com.hubEleven.order.infrastructure.client;
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "company-service")
+public interface CompanyFeignClient {
+
+	@GetMapping("/v1/companies/{companyId}")
+	CompanyResponse getCompany(@PathVariable UUID companyId);
+
+	record CompanyResponse(UUID companyId, String name) {}
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/ProductFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/ProductFeignClient.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "product-service")
 public interface ProductFeignClient {
 
-    @GetMapping("/v1/products/{productId}")
-    ProductResponse getProduct(@PathVariable UUID productId);
+	@GetMapping("/v1/products/{productId}")
+	ProductResponse getProduct(@PathVariable UUID productId);
 
-    record ProductResponse(UUID productId, String name) {}
+	record ProductResponse(UUID productId, String name) {}
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/ProductFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/ProductFeignClient.java
@@ -1,0 +1,15 @@
+package com.hubEleven.order.infrastructure.client;
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "product-service")
+public interface ProductFeignClient {
+
+    @GetMapping("/v1/products/{productId}")
+    ProductResponse getProduct(@PathVariable UUID productId);
+
+    record ProductResponse(UUID productId, String name) {}
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
@@ -1,0 +1,20 @@
+package com.hubEleven.order.infrastructure.client;
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "stock-service")
+public interface StockFeignClient {
+
+    // 재고 복원
+    @PutMapping("/v1/stocks/restore")
+    void restoreStock(@RequestBody StockRestoreRequest request);
+
+    record StockRestoreRequest(
+            UUID productId,
+            Long quantity
+    ) {}
+
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
@@ -8,10 +8,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "stock-service")
 public interface StockFeignClient {
 
-    // 재고 복원
+    // 재고 차감 (주문 생성 시)
+    @PutMapping("/v1/stocks/decrease")
+    void decreaseStock(@RequestBody StockDecreaseRequest request);
+
+    // 재고 복원 (주문 취소 시)
     @PutMapping("/v1/stocks/restore")
     void restoreStock(@RequestBody StockRestoreRequest request);
 
+    // 재고 차감 요청 DTO
+    record StockDecreaseRequest(
+            UUID productId,
+            Long quantity
+    ) {}
+
+    // 재고 복원 요청 DTO
     record StockRestoreRequest(
             UUID productId,
             Long quantity

--- a/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/client/StockFeignClient.java
@@ -8,24 +8,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "stock-service")
 public interface StockFeignClient {
 
-    // 재고 차감 (주문 생성 시)
-    @PutMapping("/v1/stocks/decrease")
-    void decreaseStock(@RequestBody StockDecreaseRequest request);
+	// 재고 차감 (주문 생성 시)
+	@PutMapping("/v1/stocks/decrease")
+	void decreaseStock(@RequestBody StockDecreaseRequest request);
 
-    // 재고 복원 (주문 취소 시)
-    @PutMapping("/v1/stocks/restore")
-    void restoreStock(@RequestBody StockRestoreRequest request);
+	// 재고 복원 (주문 취소 시)
+	@PutMapping("/v1/stocks/restore")
+	void restoreStock(@RequestBody StockRestoreRequest request);
 
-    // 재고 차감 요청 DTO
-    record StockDecreaseRequest(
-            UUID productId,
-            Long quantity
-    ) {}
+	// 재고 차감 요청 DTO
+	record StockDecreaseRequest(UUID productId, Long quantity) {}
 
-    // 재고 복원 요청 DTO
-    record StockRestoreRequest(
-            UUID productId,
-            Long quantity
-    ) {}
-
+	// 재고 복원 요청 DTO
+	record StockRestoreRequest(UUID productId, Long quantity) {}
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/configuration/SecurityConfig.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/configuration/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.hubEleven.order.infrastructure.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityFilterChain filter(HttpSecurity http) throws Exception {
+		http.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+				.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+		return http.build();
+	}
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
@@ -2,8 +2,16 @@ package com.hubEleven.order.infrastructure.repository;
 
 import com.hubEleven.order.domain.model.Order;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
 
+    @Query(
+            "SELECT o FROM Order o WHERE "
+                    + "o.deletedAt IS NULL AND "
+                    + "(:keyword IS NULL OR :keyword = '' OR o.note LIKE %:keyword%)")
+    Page<Order> searchOrders(String keyword, Pageable pageable);
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
@@ -1,0 +1,9 @@
+package com.hubEleven.order.infrastructure.repository;
+
+import com.hubEleven.order.domain.model.Order;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
+
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/JpaOrderRepository.java
@@ -9,9 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
 
-    @Query(
-            "SELECT o FROM Order o WHERE "
-                    + "o.deletedAt IS NULL AND "
-                    + "(:keyword IS NULL OR :keyword = '' OR o.note LIKE %:keyword%)")
-    Page<Order> searchOrders(String keyword, Pageable pageable);
+	@Query(
+			"SELECT o FROM Order o WHERE "
+					+ "o.deletedAt IS NULL AND "
+					+ "(:keyword IS NULL OR :keyword = '' OR o.note LIKE %:keyword%)")
+	Page<Order> searchOrders(String keyword, Pageable pageable);
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
@@ -1,0 +1,17 @@
+package com.hubEleven.order.infrastructure.repository;
+
+import com.hubEleven.order.domain.model.Order;
+import com.hubEleven.order.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryAdapter implements OrderRepository {
+
+    private final JpaOrderRepository jpaOrderRepository;
+
+    @Override
+    public Order save(Order order) {return jpaOrderRepository.save(order);}
+
+}

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
@@ -3,6 +3,8 @@ package com.hubEleven.order.infrastructure.repository;
 import com.hubEleven.order.domain.model.Order;
 import com.hubEleven.order.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +15,10 @@ public class OrderRepositoryAdapter implements OrderRepository {
 
     @Override
     public Order save(Order order) {return jpaOrderRepository.save(order);}
+
+    @Override
+    public Page<Order> searchOrders(String keyword, Pageable pageable) {
+        return jpaOrderRepository.searchOrders(keyword, pageable);
+    }
 
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.hubEleven.order.infrastructure.repository;
 
 import com.hubEleven.order.domain.model.Order;
 import com.hubEleven.order.domain.repository.OrderRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +21,11 @@ public class OrderRepositoryAdapter implements OrderRepository {
     @Override
     public Page<Order> searchOrders(String keyword, Pageable pageable) {
         return jpaOrderRepository.searchOrders(keyword, pageable);
+    }
+
+    @Override
+    public Optional<Order> findById(UUID orderId) {
+        return jpaOrderRepository.findById(orderId);
     }
 
 }

--- a/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/repository/OrderRepositoryAdapter.java
@@ -13,19 +13,20 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OrderRepositoryAdapter implements OrderRepository {
 
-    private final JpaOrderRepository jpaOrderRepository;
+	private final JpaOrderRepository jpaOrderRepository;
 
-    @Override
-    public Order save(Order order) {return jpaOrderRepository.save(order);}
+	@Override
+	public Order save(Order order) {
+		return jpaOrderRepository.save(order);
+	}
 
-    @Override
-    public Page<Order> searchOrders(String keyword, Pageable pageable) {
-        return jpaOrderRepository.searchOrders(keyword, pageable);
-    }
+	@Override
+	public Page<Order> searchOrders(String keyword, Pageable pageable) {
+		return jpaOrderRepository.searchOrders(keyword, pageable);
+	}
 
-    @Override
-    public Optional<Order> findById(UUID orderId) {
-        return jpaOrderRepository.findById(orderId);
-    }
-
+	@Override
+	public Optional<Order> findById(UUID orderId) {
+		return jpaOrderRepository.findById(orderId);
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -1,0 +1,32 @@
+package com.hubEleven.order.presentation.controller;
+
+import com.hubEleven.common.response.ApiResponse;
+import com.hubEleven.common.response.ApiResponseEntity;
+import com.hubEleven.order.application.dto.OrderResult;
+import com.hubEleven.order.application.service.OrderService;
+import com.hubEleven.order.presentation.dto.request.OrderRequests;
+import com.hubEleven.order.presentation.dto.response.OrderResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> create(
+            @Valid @RequestBody OrderRequests.Create request) {
+
+        OrderResult result = orderService.create(request);
+
+        return ApiResponseEntity.success(OrderResponse.from(result));
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -1,14 +1,19 @@
 package com.hubEleven.order.presentation.controller;
 
+import com.hubEleven.common.request.CommonPageRequest;
 import com.hubEleven.common.response.ApiResponse;
 import com.hubEleven.common.response.ApiResponseEntity;
+import com.hubEleven.common.response.CommonPageResponse;
+import com.hubEleven.common.utils.PagingUtils;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.application.service.OrderService;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.response.OrderResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +33,21 @@ public class OrderController {
         OrderResult result = orderService.create(request);
 
         return ApiResponseEntity.success(OrderResponse.from(result));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> getOrders(CommonPageRequest request) {
+
+        // Service 계층에서 Order 도메인 엔티티를 OrderResult DTO로 변환하여 조회
+        Page<OrderResult> orders =
+                orderService.searchOrders(
+                        request.keyword(),
+                        request.toPageable());
+
+        // Application 계층의 OrderResult를 Presentation 계층의 OrderResponse로 변환
+        CommonPageResponse<OrderResponse> response =
+                PagingUtils.convert(orders, OrderResponse::from);
+
+        return ApiResponseEntity.success(response);
     }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -1,10 +1,11 @@
 package com.hubEleven.order.presentation.controller;
 
-import com.hubEleven.common.request.CommonPageRequest;
-import com.hubEleven.common.response.ApiResponse;
-import com.hubEleven.common.response.ApiResponseEntity;
-import com.hubEleven.common.response.CommonPageResponse;
-import com.hubEleven.common.utils.PagingUtils;
+
+import com.commonLib.common.request.CommonPageRequest;
+import com.commonLib.common.response.ApiResponse;
+import com.commonLib.common.response.ApiResponseEntity;
+import com.commonLib.common.response.CommonPageResponse;
+import com.commonLib.common.utils.PagingUtils;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.application.service.OrderService;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -10,10 +10,12 @@ import com.hubEleven.order.application.service.OrderService;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.response.OrderResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,5 +51,13 @@ public class OrderController {
                 PagingUtils.convert(orders, OrderResponse::from);
 
         return ApiResponseEntity.success(response);
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrderDetail(@PathVariable UUID orderId) {
+
+        OrderResult result = orderService.getOrderDetail(orderId);
+
+        return ApiResponseEntity.success(OrderResponse.from(result));
     }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.hubEleven.common.response.CommonPageResponse;
 import com.hubEleven.common.utils.PagingUtils;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.application.service.OrderService;
+import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductResponse;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.response.OrderResponse;
 import jakarta.validation.Valid;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,4 +62,14 @@ public class OrderController {
 
         return ApiResponseEntity.success(OrderResponse.from(result));
     }
+
+    @PatchMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> updateOrder(
+            @PathVariable UUID orderId, @Valid @RequestBody OrderRequests.Update request) {
+
+        OrderResult result = orderService.updateOrder(orderId, request);
+
+        return ApiResponseEntity.success(OrderResponse.from(result));
+    }
+
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -94,4 +94,13 @@ public class OrderController {
 
         return ApiResponseEntity.success(response);
     }
+
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancelOrder(
+            @PathVariable UUID orderId, Long userId) {
+
+        orderService.cancelOrder(orderId, userId);
+
+        return ApiResponseEntity.success(null);
+    }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -7,7 +7,6 @@ import com.hubEleven.common.response.CommonPageResponse;
 import com.hubEleven.common.utils.PagingUtils;
 import com.hubEleven.order.application.dto.OrderResult;
 import com.hubEleven.order.application.service.OrderService;
-import com.hubEleven.order.infrastructure.client.ProductFeignClient.ProductResponse;
 import com.hubEleven.order.presentation.dto.request.OrderRequests;
 import com.hubEleven.order.presentation.dto.response.OrderResponse;
 import jakarta.validation.Valid;
@@ -29,78 +28,71 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OrderController {
 
-    private final OrderService orderService;
+	private final OrderService orderService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<OrderResponse>> create(
-            @Valid @RequestBody OrderRequests.Create request) {
+	@PostMapping
+	public ResponseEntity<ApiResponse<OrderResponse>> create(
+			@Valid @RequestBody OrderRequests.Create request) {
 
-        OrderResult result = orderService.create(request);
+		OrderResult result = orderService.create(request);
 
-        return ApiResponseEntity.success(OrderResponse.from(result));
-    }
+		return ApiResponseEntity.success(OrderResponse.from(result));
+	}
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> getOrders(CommonPageRequest request) {
+	@GetMapping
+	public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> getOrders(
+			CommonPageRequest request) {
 
-        // Service 계층에서 Order 도메인 엔티티를 OrderResult DTO로 변환하여 조회
-        Page<OrderResult> orders =
-                orderService.searchOrders(
-                        request.keyword(),
-                        request.toPageable());
+		// Service 계층에서 Order 도메인 엔티티를 OrderResult DTO로 변환하여 조회
+		Page<OrderResult> orders = orderService.searchOrders(request.keyword(), request.toPageable());
 
-        // Application 계층의 OrderResult를 Presentation 계층의 OrderResponse로 변환
-        CommonPageResponse<OrderResponse> response =
-                PagingUtils.convert(orders, OrderResponse::from);
+		// Application 계층의 OrderResult를 Presentation 계층의 OrderResponse로 변환
+		CommonPageResponse<OrderResponse> response = PagingUtils.convert(orders, OrderResponse::from);
 
-        return ApiResponseEntity.success(response);
-    }
+		return ApiResponseEntity.success(response);
+	}
 
-    @GetMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<OrderResponse>> getOrderDetail(@PathVariable UUID orderId) {
+	@GetMapping("/{orderId}")
+	public ResponseEntity<ApiResponse<OrderResponse>> getOrderDetail(@PathVariable UUID orderId) {
 
-        OrderResult result = orderService.getOrderDetail(orderId);
+		OrderResult result = orderService.getOrderDetail(orderId);
 
-        return ApiResponseEntity.success(OrderResponse.from(result));
-    }
+		return ApiResponseEntity.success(OrderResponse.from(result));
+	}
 
-    @PatchMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<OrderResponse>> updateOrder(
-            @PathVariable UUID orderId, @Valid @RequestBody OrderRequests.Update request) {
+	@PatchMapping("/{orderId}")
+	public ResponseEntity<ApiResponse<OrderResponse>> updateOrder(
+			@PathVariable UUID orderId, @Valid @RequestBody OrderRequests.Update request) {
 
-        OrderResult result = orderService.updateOrder(orderId, request);
+		OrderResult result = orderService.updateOrder(orderId, request);
 
-        return ApiResponseEntity.success(OrderResponse.from(result));
-    }
+		return ApiResponseEntity.success(OrderResponse.from(result));
+	}
 
-    @DeleteMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<Void>> deleteOrder(
-            @PathVariable UUID orderId, Long userId) {
+	@DeleteMapping("/{orderId}")
+	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable UUID orderId, Long userId) {
 
-        orderService.deleteOrder(orderId, userId);
+		orderService.deleteOrder(orderId, userId);
 
-        return ApiResponseEntity.success(null);
-    }
+		return ApiResponseEntity.success(null);
+	}
 
-    @GetMapping("/search")
-    public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> searchOrders(
-            CommonPageRequest request) {
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> searchOrders(
+			CommonPageRequest request) {
 
-        Page<OrderResult> orders =
-                orderService.searchOrders(request.keyword(), request.toPageable());
+		Page<OrderResult> orders = orderService.searchOrders(request.keyword(), request.toPageable());
 
-        CommonPageResponse<OrderResponse> response =
-                PagingUtils.convert(orders, OrderResponse::from);
+		CommonPageResponse<OrderResponse> response = PagingUtils.convert(orders, OrderResponse::from);
 
-        return ApiResponseEntity.success(response);
-    }
+		return ApiResponseEntity.success(response);
+	}
 
-    @PostMapping("/{orderId}/cancel")
-    public ResponseEntity<ApiResponse<Void>> cancelOrder(
-            @PathVariable UUID orderId, Long userId) {
+	@PostMapping("/{orderId}/cancel")
+	public ResponseEntity<ApiResponse<Void>> cancelOrder(@PathVariable UUID orderId, Long userId) {
 
-        orderService.cancelOrder(orderId, userId);
+		orderService.cancelOrder(orderId, userId);
 
-        return ApiResponseEntity.success(null);
-    }
+		return ApiResponseEntity.success(null);
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -1,6 +1,5 @@
 package com.hubEleven.order.presentation.controller;
 
-
 import com.commonLib.common.request.CommonPageRequest;
 import com.commonLib.common.response.ApiResponse;
 import com.commonLib.common.response.ApiResponseEntity;

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -72,4 +73,12 @@ public class OrderController {
         return ApiResponseEntity.success(OrderResponse.from(result));
     }
 
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<Void>> deleteOrder(
+            @PathVariable UUID orderId, Long userId) {
+
+        orderService.deleteOrder(orderId, userId);
+
+        return ApiResponseEntity.success(null);
+    }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/controller/OrderController.java
@@ -81,4 +81,17 @@ public class OrderController {
 
         return ApiResponseEntity.success(null);
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<CommonPageResponse<OrderResponse>>> searchOrders(
+            CommonPageRequest request) {
+
+        Page<OrderResult> orders =
+                orderService.searchOrders(request.keyword(), request.toPageable());
+
+        CommonPageResponse<OrderResponse> response =
+                PagingUtils.convert(orders, OrderResponse::from);
+
+        return ApiResponseEntity.success(response);
+    }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
@@ -7,15 +7,15 @@ import java.util.UUID;
 
 public class OrderRequests {
 
-    public record Create(
-            @NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
-            @NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
-            @NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
-            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+	public record Create(
+			@NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
+			@NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
+			@NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
+			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
 
-    public record Update(
-            @Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
-            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+	public record Update(
+			@Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
+			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
@@ -1,5 +1,6 @@
 package com.hubEleven.order.presentation.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
@@ -12,5 +13,9 @@ public class OrderRequests {
             @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
             @NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
             @NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
+            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+
+    public record Update(
+            @Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
             @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
@@ -1,0 +1,16 @@
+package com.hubEleven.order.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public class OrderRequests {
+
+    public record Create(
+            @NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
+            @NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
+            @NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
+            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+}

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
@@ -4,22 +4,22 @@ import com.hubEleven.order.application.dto.OrderResult;
 import java.util.UUID;
 
 public record OrderResponse(
-        UUID oderId,
-        UUID requestorCompanyId,
-        UUID recipientCompanyId,
-        UUID productId,
-        UUID deliveryId,
-        Long quantity,
-        String note) {
+		UUID oderId,
+		UUID requestorCompanyId,
+		UUID recipientCompanyId,
+		UUID productId,
+		UUID deliveryId,
+		Long quantity,
+		String note) {
 
-    public static OrderResponse from(OrderResult orderResult) {
-        return new OrderResponse(
-                orderResult.oderId(),
-                orderResult.requestorCompanyId(),
-                orderResult.recipientCompanyId(),
-                orderResult.productId(),
-                orderResult.deliveryId(),
-                orderResult.quantity(),
-                orderResult.note());
-    }
+	public static OrderResponse from(OrderResult orderResult) {
+		return new OrderResponse(
+				orderResult.oderId(),
+				orderResult.requestorCompanyId(),
+				orderResult.recipientCompanyId(),
+				orderResult.productId(),
+				orderResult.deliveryId(),
+				orderResult.quantity(),
+				orderResult.note());
+	}
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
@@ -1,0 +1,27 @@
+package com.hubEleven.order.presentation.dto.response;
+
+import com.hubEleven.order.application.dto.OrderResult;
+import java.util.UUID;
+
+public record OrderResponse(
+        UUID oderId,
+        UUID requestorCompanyId,
+        UUID recipientCompanyId,
+        UUID productId,
+        String productName,
+        UUID deliveryId,
+        Long quantity,
+        String note) {
+
+    public static OrderResponse from(OrderResult orderResult) {
+        return new OrderResponse(
+                orderResult.oderId(),
+                orderResult.requestorCompanyId(),
+                orderResult.recipientCompanyId(),
+                orderResult.productId(),
+                orderResult.productName(),
+                orderResult.deliveryId(),
+                orderResult.quantity(),
+                orderResult.note());
+    }
+}

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/response/OrderResponse.java
@@ -8,7 +8,6 @@ public record OrderResponse(
         UUID requestorCompanyId,
         UUID recipientCompanyId,
         UUID productId,
-        String productName,
         UUID deliveryId,
         Long quantity,
         String note) {
@@ -19,7 +18,6 @@ public record OrderResponse(
                 orderResult.requestorCompanyId(),
                 orderResult.recipientCompanyId(),
                 orderResult.productId(),
-                orderResult.productName(),
                 orderResult.deliveryId(),
                 orderResult.quantity(),
                 orderResult.note());

--- a/order/src/main/resources/application.properties
+++ b/order/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=order
-
-springdoc.api-docs.path=/v3/api-docs
-springdoc.swagger-ui.path=/swagger-ui.html
-springdoc.default-server-url=http://localhost:8080

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: order-service
+  config:
+    import: "configserver:"
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config
+
+server:
+  port: 0
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}

--- a/product/src/main/java/com/hubEleven/product/application/service/ProductService.java
+++ b/product/src/main/java/com/hubEleven/product/application/service/ProductService.java
@@ -2,8 +2,6 @@ package com.hubEleven.product.application.service;
 
 import com.hubEleven.product.application.dto.ProductResult;
 import com.hubEleven.product.presentation.dto.request.ProductRequests;
-import com.hubEleven.product.presentation.dto.request.ProductRequests.Update;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/product/src/main/java/com/hubEleven/product/application/service/ProductService.java
+++ b/product/src/main/java/com/hubEleven/product/application/service/ProductService.java
@@ -15,7 +15,7 @@ public interface ProductService {
 
 	ProductResult getProduct(UUID productId);
 
-	ProductResult updateProduct(UUID productId, @Valid Update request);
+	ProductResult updateProduct(UUID productId, ProductRequests.Update request);
 
 	void deleteProduct(UUID productId, Long userId);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
+++ b/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
@@ -5,12 +5,7 @@ import java.util.UUID;
 
 // Service 계층의 반환용 DTO (Domain 엔티티와 API 응답 사이의 중간 계층)
 public record StockResult(
-		UUID stockId,
-		UUID productId,
-		String productName,
-		UUID hubId,
-		UUID companyId,
-		Long quantity) {
+		UUID stockId, UUID productId, String productName, UUID hubId, UUID companyId, Long quantity) {
 	public static StockResult from(Stock stock, String productName) {
 		return new StockResult(
 				stock.getStockId(),

--- a/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
+++ b/product/src/main/java/com/hubEleven/stock/application/dto/StockResult.java
@@ -10,7 +10,7 @@ public record StockResult(
 		String productName,
 		UUID hubId,
 		UUID companyId,
-		Integer quantity) {
+		Long quantity) {
 	public static StockResult from(Stock stock, String productName) {
 		return new StockResult(
 				stock.getStockId(),

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -2,8 +2,6 @@ package com.hubEleven.stock.application.service;
 
 import com.hubEleven.stock.application.dto.StockResult;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
-import com.hubEleven.stock.presentation.dto.request.StockRequests.Create;
-import jakarta.validation.Valid;
 import java.util.UUID;
 
 public interface StockService {
@@ -12,7 +10,7 @@ public interface StockService {
 
 	StockResult getStockByProductId(UUID productId);
 
-    StockResult decreaseStock(StockRequests.Decrease request);
+	StockResult decreaseStock(StockRequests.Decrease request);
 
-    StockResult restoreStock(StockRequests.Restore request);
+	StockResult restoreStock(StockRequests.Restore request);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -1,6 +1,7 @@
 package com.hubEleven.stock.application.service;
 
 import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
 import com.hubEleven.stock.presentation.dto.request.StockRequests.Create;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -10,4 +11,6 @@ public interface StockService {
 	StockResult create(@Valid Create request);
 
 	StockResult getStockByProductId(UUID productId);
+
+    StockResult restoreStock(StockRequests.Restore request);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockService.java
@@ -8,9 +8,11 @@ import java.util.UUID;
 
 public interface StockService {
 
-	StockResult create(@Valid Create request);
+	StockResult create(StockRequests.Create request);
 
 	StockResult getStockByProductId(UUID productId);
+
+    StockResult decreaseStock(StockRequests.Decrease request);
 
     StockResult restoreStock(StockRequests.Restore request);
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -23,19 +23,19 @@ public class StockServiceImpl implements StockService {
 	private final StockRepository stockRepository;
 	private final ProductRepository productRepository;
 
-    // 상품 존재 여부 확인 메서드
-    private Product validateProductExists(UUID productId) {
-        return productRepository
-                .findById(productId)
-                .orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
-    }
+	// 상품 존재 여부 확인 메서드
+	private Product validateProductExists(UUID productId) {
+		return productRepository
+				.findById(productId)
+				.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+	}
 
-    // 재고 존재 여부 확인 메서드
-    private Stock validateStockExists(UUID productId) {
-        return stockRepository
-                .findByProductId(productId)
-                .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
-    }
+	// 재고 존재 여부 확인 메서드
+	private Stock validateStockExists(UUID productId) {
+		return stockRepository
+				.findByProductId(productId)
+				.orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+	}
 
 	@Override
 	@Transactional
@@ -56,9 +56,9 @@ public class StockServiceImpl implements StockService {
 	public StockResult getStockByProductId(UUID productId) {
 
 		// 상품 존재 여부 확인
-        Product product = validateProductExists(productId);
+		Product product = validateProductExists(productId);
 
-        // 삭제된 상품인지 확인
+		// 삭제된 상품인지 확인
 		if (product.isDeleted()) {
 			throw new GlobalException(PRODUCT_DELETED);
 		}
@@ -69,37 +69,36 @@ public class StockServiceImpl implements StockService {
 		return StockResult.from(stock, product.getName());
 	}
 
-    @Override
-    @Transactional
-    public StockResult decreaseStock(StockRequests.Decrease request) {
+	@Override
+	@Transactional
+	public StockResult decreaseStock(StockRequests.Decrease request) {
 
-        // 상품 존재 여부 확인
-        Product product = validateProductExists(request.productId());
+		// 상품 존재 여부 확인
+		Product product = validateProductExists(request.productId());
 
-        // 재고 조회
-        Stock stock = validateStockExists(request.productId());
+		// 재고 조회
+		Stock stock = validateStockExists(request.productId());
 
-        // 재고 차감
-        stock.decreaseQuantity(request.quantity()); // ToDo : 재고 부족 예외 처리
+		// 재고 차감
+		stock.decreaseQuantity(request.quantity()); // ToDo : 재고 부족 예외 처리
 
-        return StockResult.from(stock, product.getName());
-    }
+		return StockResult.from(stock, product.getName());
+	}
 
+	@Override
+	@Transactional
+	public StockResult restoreStock(StockRequests.Restore request) {
+		// 상품 존재 여부 확인
+		Product product = validateProductExists(request.productId());
 
-    @Override
-    @Transactional
-    public StockResult restoreStock(StockRequests.Restore request) {
-        // 상품 존재 여부 확인
-        Product product = validateProductExists(request.productId());
+		// 재고 조회
+		Stock stock = validateStockExists(request.productId());
 
-        // 재고 조회
-        Stock stock = validateStockExists(request.productId());
+		// 재고 복원 로직
+		stock.restoreQuantity(request.quantity()); // ToDo : 재고 복원 예외 처리
 
-        // 재고 복원 로직
-        stock.restoreQuantity(request.quantity()); // ToDo : 재고 복원 예외 처리
+		Stock updatedStock = stockRepository.save(stock);
 
-        Stock updatedStock = stockRepository.save(stock);
-
-        return StockResult.from(updatedStock, product.getName());
-    }
+		return StockResult.from(updatedStock, product.getName());
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -23,14 +23,18 @@ public class StockServiceImpl implements StockService {
 	private final StockRepository stockRepository;
 	private final ProductRepository productRepository;
 
+    // 상품 존재 여부 확인 메서드
+    private Product validateProductExists(UUID productId) {
+        return productRepository
+                .findById(productId)
+                .orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+    }
+
 	@Override
 	@Transactional
 	public StockResult create(StockRequests.Create request) {
 		// 상품 존재 여부 확인
-		Product product =
-				productRepository
-						.findById(request.productId())
-						.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+		Product product = validateProductExists(request.productId());
 
 		Stock stock =
 				Stock.create(request.quantity(), request.productId(), request.companyId(), request.hubId());
@@ -45,12 +49,9 @@ public class StockServiceImpl implements StockService {
 	public StockResult getStockByProductId(UUID productId) {
 
 		// 상품 존재 여부 확인
-		Product product =
-				productRepository
-						.findById(productId)
-						.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+        Product product = validateProductExists(productId);
 
-		// 삭제된 상품인지 확인
+        // 삭제된 상품인지 확인
 		if (product.isDeleted()) {
 			throw new GlobalException(PRODUCT_DELETED);
 		}
@@ -63,4 +64,24 @@ public class StockServiceImpl implements StockService {
 
 		return StockResult.from(stock, product.getName());
 	}
+
+    @Override
+    @Transactional
+    public StockResult restoreStock(StockRequests.Restore request) {
+        // 상품 존재 여부 확인
+        Product product = validateProductExists(request.productId());
+
+        // 재고 조회
+        Stock stock =
+                stockRepository
+                        .findByProductId(request.productId())
+                        .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+
+        // 재고 복원 로직
+        stock.restoreQuantity(request.quantity());
+
+        Stock updatedStock = stockRepository.save(stock);
+
+        return StockResult.from(updatedStock, product.getName());
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -30,6 +30,13 @@ public class StockServiceImpl implements StockService {
                 .orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
     }
 
+    // 재고 존재 여부 확인 메서드
+    private Stock validateStockExists(UUID productId) {
+        return stockRepository
+                .findByProductId(productId)
+                .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+    }
+
 	@Override
 	@Transactional
 	public StockResult create(StockRequests.Create request) {
@@ -57,13 +64,27 @@ public class StockServiceImpl implements StockService {
 		}
 
 		// 재고 조회
-		Stock stock =
-				stockRepository
-						.findByProductId(productId)
-						.orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+		Stock stock = validateStockExists(productId);
 
 		return StockResult.from(stock, product.getName());
 	}
+
+    @Override
+    @Transactional
+    public StockResult decreaseStock(StockRequests.Decrease request) {
+
+        // 상품 존재 여부 확인
+        Product product = validateProductExists(request.productId());
+
+        // 재고 조회
+        Stock stock = validateStockExists(request.productId());
+
+        // 재고 차감
+        stock.decreaseQuantity(request.quantity()); // ToDo : 재고 부족 예외 처리
+
+        return StockResult.from(stock, product.getName());
+    }
+
 
     @Override
     @Transactional
@@ -72,13 +93,10 @@ public class StockServiceImpl implements StockService {
         Product product = validateProductExists(request.productId());
 
         // 재고 조회
-        Stock stock =
-                stockRepository
-                        .findByProductId(request.productId())
-                        .orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+        Stock stock = validateStockExists(request.productId());
 
         // 재고 복원 로직
-        stock.restoreQuantity(request.quantity());
+        stock.restoreQuantity(request.quantity()); // ToDo : 재고 복원 예외 처리
 
         Stock updatedStock = stockRepository.save(stock);
 

--- a/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
@@ -53,6 +53,12 @@ public class Stock extends BaseEntity {
 				.build();
 	}
 
+    public void decreaseQuantity(Long decreaseQuantity) {
+        if (decreaseQuantity != null && decreaseQuantity > 0 && this.quantity >= decreaseQuantity) {
+            this.quantity -= decreaseQuantity;
+        }
+    }
+
     public void restoreQuantity(Long restoreQuantity) {
         if (restoreQuantity != null && restoreQuantity > 0) {
             this.quantity += restoreQuantity;

--- a/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
@@ -34,17 +34,17 @@ public class Stock extends BaseEntity {
 	private UUID companyId;
 
 	@Column(name = "quantity", nullable = false)
-	private Integer quantity;
+	private Long quantity;
 
 	@Builder(access = AccessLevel.PRIVATE)
-	private Stock(Integer quantity, UUID productId, UUID companyId, UUID hubId) {
+	private Stock(Long quantity, UUID productId, UUID companyId, UUID hubId) {
 		this.quantity = quantity;
 		this.productId = productId;
 		this.companyId = companyId;
 		this.hubId = hubId;
 	}
 
-	public static Stock create(Integer quantity, UUID productId, UUID companyId, UUID hubId) {
+	public static Stock create(Long quantity, UUID productId, UUID companyId, UUID hubId) {
 		return Stock.builder()
 				.quantity(quantity)
 				.productId(productId)
@@ -52,4 +52,10 @@ public class Stock extends BaseEntity {
 				.hubId(hubId)
 				.build();
 	}
+
+    public void restoreQuantity(Long restoreQuantity) {
+        if (restoreQuantity != null && restoreQuantity > 0) {
+            this.quantity += restoreQuantity;
+        }
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/model/Stock.java
@@ -53,15 +53,15 @@ public class Stock extends BaseEntity {
 				.build();
 	}
 
-    public void decreaseQuantity(Long decreaseQuantity) {
-        if (decreaseQuantity != null && decreaseQuantity > 0 && this.quantity >= decreaseQuantity) {
-            this.quantity -= decreaseQuantity;
-        }
-    }
+	public void decreaseQuantity(Long decreaseQuantity) {
+		if (decreaseQuantity != null && decreaseQuantity > 0 && this.quantity >= decreaseQuantity) {
+			this.quantity -= decreaseQuantity;
+		}
+	}
 
-    public void restoreQuantity(Long restoreQuantity) {
-        if (restoreQuantity != null && restoreQuantity > 0) {
-            this.quantity += restoreQuantity;
-        }
-    }
+	public void restoreQuantity(Long restoreQuantity) {
+		if (restoreQuantity != null && restoreQuantity > 0) {
+			this.quantity += restoreQuantity;
+		}
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -43,6 +43,16 @@ public class StockController {
 		return ApiResponseEntity.success(StockResponse.from(result));
 	}
 
+    @PutMapping
+    public ResponseEntity<ApiResponse<StockResponse>> decreaseStock(
+            @Valid @RequestBody StockRequests.Decrease request) {
+
+        // 재고 감소 로직 호출
+        StockResult result = stockService.decreaseStock(request);
+
+        return ApiResponseEntity.success(StockResponse.from(result));
+    }
+
     @PutMapping("/restore")
     public ResponseEntity<ApiResponse<StockResponse>> restoreStock(
             @Valid @RequestBody StockRequests.Restore request) {

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -43,23 +43,23 @@ public class StockController {
 		return ApiResponseEntity.success(StockResponse.from(result));
 	}
 
-    @PutMapping
-    public ResponseEntity<ApiResponse<StockResponse>> decreaseStock(
-            @Valid @RequestBody StockRequests.Decrease request) {
+	@PutMapping
+	public ResponseEntity<ApiResponse<StockResponse>> decreaseStock(
+			@Valid @RequestBody StockRequests.Decrease request) {
 
-        // 재고 감소 로직 호출
-        StockResult result = stockService.decreaseStock(request);
+		// 재고 감소 로직 호출
+		StockResult result = stockService.decreaseStock(request);
 
-        return ApiResponseEntity.success(StockResponse.from(result));
-    }
+		return ApiResponseEntity.success(StockResponse.from(result));
+	}
 
-    @PutMapping("/restore")
-    public ResponseEntity<ApiResponse<StockResponse>> restoreStock(
-            @Valid @RequestBody StockRequests.Restore request) {
+	@PutMapping("/restore")
+	public ResponseEntity<ApiResponse<StockResponse>> restoreStock(
+			@Valid @RequestBody StockRequests.Restore request) {
 
-        // 재고 복원 로직 호출
-        StockResult result = stockService.restoreStock(request);
+		// 재고 복원 로직 호출
+		StockResult result = stockService.restoreStock(request);
 
-        return ApiResponseEntity.success(StockResponse.from(result));
-    }
+		return ApiResponseEntity.success(StockResponse.from(result));
+	}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/controller/StockController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,4 +42,14 @@ public class StockController {
 
 		return ApiResponseEntity.success(StockResponse.from(result));
 	}
+
+    @PutMapping("/restore")
+    public ResponseEntity<ApiResponse<StockResponse>> restoreStock(
+            @Valid @RequestBody StockRequests.Restore request) {
+
+        // 재고 복원 로직 호출
+        StockResult result = stockService.restoreStock(request);
+
+        return ApiResponseEntity.success(StockResponse.from(result));
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -23,4 +23,10 @@ public class StockRequests {
             @NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
                     Long quantity
     ) {}
+
+    public record Decrease(
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+                    Long quantity
+    ) {}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -13,20 +13,15 @@ public class StockRequests {
 			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
 			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
 
-    public record Update(
-            @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
-                    Long quantity
-    ) {}
+	public record Update(@Min(value = 0, message = "수량은 0 이상이어야 합니다.") Long quantity) {}
 
-    public record Restore(
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
-                    Long quantity
-    ) {}
+	public record Restore(
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
+					Long quantity) {}
 
-    public record Decrease(
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
-                    Long quantity
-    ) {}
+	public record Decrease(
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+					Long quantity) {}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -8,8 +8,19 @@ public class StockRequests {
 
 	public record Create(
 			@NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
-					Integer quantity,
+					Long quantity,
 			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
 			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
 			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
+
+    public record Update(
+            @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+                    Long quantity
+    ) {}
+
+    public record Restore(
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
+                    Long quantity
+    ) {}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
@@ -9,7 +9,7 @@ public record StockResponse(
 		String productName,
 		UUID hubId,
 		UUID companyId,
-		Integer quantity) {
+		Long quantity) {
 
 	public static StockResponse from(StockResult stockResult) {
 		return new StockResponse(

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/response/StockResponse.java
@@ -4,12 +4,7 @@ import com.hubEleven.stock.application.dto.StockResult;
 import java.util.UUID;
 
 public record StockResponse(
-		UUID stockId,
-		UUID productId,
-		String productName,
-		UUID hubId,
-		UUID companyId,
-		Long quantity) {
+		UUID stockId, UUID productId, String productName, UUID hubId, UUID companyId, Long quantity) {
 
 	public static StockResponse from(StockResult stockResult) {
 		return new StockResponse(


### PR DESCRIPTION
### #️⃣연관된 이슈
주문(order) 도메인 [API 명세서](https://www.notion.so/teamsparta/29d2dc3ef51481fc89a1dc8bffe1bebd?v=29d2dc3ef51481439a48000cab43139e&p=29f2dc3ef5148082aab8d5058a37667c&pm=s) 기반 기능 구현

### 🪄작업 내용 
- [x] MSA 기본 설정
- [x] 주문 생성
- [x] 주문 전체 조회
- [x] 주문 단건 조회
- [x] 주문 수정
- [x] 주문 취소
- [x] 주문 삭제
- [x] 주문 검색

### ✏️리뷰 요청
- 주문 생성 시 재고 감소 service 로직 확인 부탁드립니다.
- 주문 생성 시 배송 함께 생성되는 로직 확인 부탁드립니다.
- 주문 취소 시 재고 수량 복원 service 로직 확인 부탁드립니다.
