### PR TITLE
[feat] 허브(Hub) 위치 변경 시 도메인 이벤트 발행

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.github.Doritosch:commonLib:1.0.2'
+    implementation 'com.github.Doritosch:commonLib:v1.0.5'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/hubEleven/hub/application/event/HubEventHandler.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/event/HubEventHandler.java
@@ -1,0 +1,78 @@
+package com.hubEleven.hub.application.event;
+
+import com.hubEleven.hub.application.service.HubRouteServiceImpl;
+import com.hubEleven.hub.domain.event.HubCreatedEvent;
+import com.hubEleven.hub.domain.event.HubDeletedEvent;
+import com.hubEleven.hub.domain.event.HubLocationChangedEvent;
+import com.hubEleven.hub.domain.repository.HubRouteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubEventHandler {
+
+	private final HubRouteRepository hubRouteRepository;
+	private final HubRouteServiceImpl hubRouteService;
+
+	// hub 생성 이벤트
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleHubCreated(HubCreatedEvent event) {
+		log.info("Hub 생성 이벤트 수신: hubId={}", event.getHubId());
+
+		try {
+			// 기존 Route 전체 soft delete
+			hubRouteRepository.softDeleteAll(1L); // TODO: 실제 userId로 변경 필요
+
+			// 전체 경로 재계산
+			hubRouteService.generateAllRoutes();
+
+		} catch (Exception e) {
+			log.error("Hub 생성 이벤트 처리 중 오류 발생: hubId={}", event.getHubId(), e);
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleHubLocationChanged(HubLocationChangedEvent event) {
+		log.info(
+				"Hub 위치 변경 이벤트 수신: hubId={}, newLocation={}", event.getHubId(), event.getNewLocation());
+
+		try {
+			// 기존 Route 전체 soft delete
+			hubRouteRepository.softDeleteAll(1L); // TODO: 실제 userId로 변경 필요
+
+			// 전체 경로 재계산
+			hubRouteService.generateAllRoutes();
+
+		} catch (Exception e) {
+			log.error("Hub 위치 변경 이벤트 처리 중 오류 발생: hubId={}", event.getHubId(), e);
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleHubDeleted(HubDeletedEvent event) {
+		log.info("Hub 삭제 이벤트 수신: hubId={}", event.getHubId());
+
+		try {
+			hubRouteRepository.softDeleteAll(1L); // TODO: 실제 userId로 변경 필요
+
+			hubRouteService.generateAllRoutes();
+
+		} catch (Exception e) {
+			log.error("Hub 삭제 이벤트 처리 중 오류 발생: hubId={}", event.getHubId(), e);
+		}
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/application/service/HubRouteService.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/HubRouteService.java
@@ -4,7 +4,7 @@ import com.hubEleven.hub.application.dto.RouteResult;
 import java.util.List;
 import java.util.UUID;
 
-public interface RouteService {
+public interface HubRouteService {
 
 	void generateAllRoutes();
 

--- a/hub/src/main/java/com/hubEleven/hub/application/service/HubRouteServiceImpl.java
+++ b/hub/src/main/java/com/hubEleven/hub/application/service/HubRouteServiceImpl.java
@@ -1,6 +1,6 @@
 package com.hubEleven.hub.application.service;
 
-import com.hubEleven.common.exception.GlobalException;
+import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.hub.application.dto.RouteResult;
 import com.hubEleven.hub.application.util.RouteCalculationResult;
 import com.hubEleven.hub.application.util.RouteCalculator;
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RouteServiceImpl implements RouteService {
+public class HubRouteServiceImpl implements HubRouteService {
 
 	private final HubRepository hubRepository;
 	private final HubRouteRepository hubRouteRepository;

--- a/hub/src/main/java/com/hubEleven/hub/domain/event/HubCreatedEvent.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/event/HubCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.hubEleven.hub.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubCreatedEvent {
+
+	private final UUID hubId;
+	private final LocalDateTime occurredAt;
+
+	public HubCreatedEvent(UUID hubId) {
+		this.hubId = hubId;
+		this.occurredAt = LocalDateTime.now();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/domain/event/HubDeletedEvent.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/event/HubDeletedEvent.java
@@ -1,0 +1,17 @@
+package com.hubEleven.hub.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubDeletedEvent {
+
+	private final UUID hubId;
+	private final LocalDateTime occurredAt;
+
+	public HubDeletedEvent(UUID hubId) {
+		this.hubId = hubId;
+		this.occurredAt = LocalDateTime.now();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/domain/event/HubLocationChangedEvent.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/event/HubLocationChangedEvent.java
@@ -1,0 +1,20 @@
+package com.hubEleven.hub.domain.event;
+
+import com.hubEleven.hub.domain.vo.Location;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubLocationChangedEvent {
+
+	private final UUID hubId;
+	private final Location newLocation;
+	private final LocalDateTime occurredAt;
+
+	public HubLocationChangedEvent(UUID hubId, Location newLocation) {
+		this.hubId = hubId;
+		this.newLocation = newLocation;
+		this.occurredAt = LocalDateTime.now();
+	}
+}

--- a/hub/src/main/java/com/hubEleven/hub/domain/model/Hub.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/model/Hub.java
@@ -1,5 +1,8 @@
 package com.hubEleven.hub.domain.model;
 
+import com.hubEleven.hub.domain.event.HubCreatedEvent;
+import com.hubEleven.hub.domain.event.HubDeletedEvent;
+import com.hubEleven.hub.domain.event.HubLocationChangedEvent;
 import com.hubEleven.hub.domain.vo.Location;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -8,12 +11,18 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.AfterDomainEventPublication;
+import org.springframework.data.domain.DomainEvents;
 
 @Getter
 @NoArgsConstructor
@@ -53,6 +62,9 @@ public class Hub {
 	@Column(name = "deleted_by")
 	private Long deletedBy;
 
+	@Transient @Builder.Default
+	private final List<Object> domainEvents = new ArrayList<>(); // 트랜잭션에서 발생하는 이벤트 추가할 리스트
+
 	public static Hub create(
 			String name,
 			String address,
@@ -60,13 +72,38 @@ public class Hub {
 			Double longitude,
 			String regionCode,
 			Long createdBy) {
-		return Hub.builder()
-				.name(name)
-				.location(Location.of(address, latitude, longitude))
-				.regionCode(regionCode)
-				.createdAt(LocalDateTime.now())
-				.createdBy(createdBy)
-				.build();
+
+		Hub hub =
+				Hub.builder()
+						.name(name)
+						.location(Location.of(address, latitude, longitude))
+						.regionCode(regionCode)
+						.createdAt(LocalDateTime.now())
+						.createdBy(createdBy)
+						.build();
+		hub.registerEvent(new HubCreatedEvent(hub.hubId));
+
+		return hub;
+	}
+
+	public static Hub createNoEvent(
+			String name,
+			String address,
+			Double latitude,
+			Double longitude,
+			String regionCode,
+			Long createdBy) {
+
+		Hub hub =
+				Hub.builder()
+						.name(name)
+						.location(Location.of(address, latitude, longitude))
+						.regionCode(regionCode)
+						.createdAt(LocalDateTime.now())
+						.createdBy(createdBy)
+						.build();
+
+		return hub;
 	}
 
 	public void update(
@@ -77,6 +114,8 @@ public class Hub {
 			String regionCode,
 			Long updatedBy) {
 
+		boolean locationChanged = false;
+
 		if (name != null) {
 			this.name = name;
 		}
@@ -86,7 +125,12 @@ public class Hub {
 			Double newLatitude = latitude != null ? latitude : this.location.getLatitude();
 			Double newLongitude = longitude != null ? longitude : this.location.getLongitude();
 
-			this.location = Location.of(newAddress, newLatitude, newLongitude);
+			Location newLocation = Location.of(newAddress, newLatitude, newLongitude);
+
+			if (!this.location.equals(newLocation)) {
+				this.location = newLocation;
+				locationChanged = true;
+			}
 		}
 
 		if (regionCode != null) {
@@ -95,14 +139,34 @@ public class Hub {
 
 		this.updatedAt = LocalDateTime.now();
 		this.updatedBy = updatedBy;
+
+		if (locationChanged) {
+			registerEvent(new HubLocationChangedEvent(this.hubId, this.location));
+		}
 	}
 
 	public void softDelete(Long deletedBy) {
 		this.deletedAt = LocalDateTime.now();
 		this.deletedBy = deletedBy;
+
+		registerEvent(new HubDeletedEvent(this.hubId));
 	}
 
 	public boolean isDeleted() {
 		return deletedAt != null;
+	}
+
+	protected void registerEvent(Object event) {
+		this.domainEvents.add(event);
+	}
+
+	@DomainEvents
+	public List<Object> getDomainEvents() {
+		return Collections.unmodifiableList(domainEvents);
+	}
+
+	@AfterDomainEventPublication
+	public void clearDomainEvents() {
+		this.domainEvents.clear();
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/domain/model/HubRoute.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/model/HubRoute.java
@@ -99,6 +99,10 @@ public class HubRoute {
 	public void softDelete(Long deletedBy) {
 		this.deletedAt = LocalDateTime.now();
 		this.deletedBy = deletedBy;
+
+		for (HubRouteSegment segment : segments) {
+			segment.softDelete(deletedBy);
+		}
 	}
 
 	public boolean isDeleted() {

--- a/hub/src/main/java/com/hubEleven/hub/domain/model/HubRouteSegment.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/model/HubRouteSegment.java
@@ -54,6 +54,18 @@ public class HubRouteSegment {
 	@Column(name = "created_by", nullable = false)
 	private Long createdBy;
 
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+
 	public static HubRouteSegment create(
 			UUID fromHubId,
 			UUID toHubId,
@@ -71,6 +83,11 @@ public class HubRouteSegment {
 				.createdAt(LocalDateTime.now())
 				.createdBy(createdBy)
 				.build();
+	}
+
+	public void softDelete(Long deletedBy) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = deletedBy;
 	}
 
 	void setHubRoute(HubRoute hubRoute) {

--- a/hub/src/main/java/com/hubEleven/hub/domain/repository/HubRouteRepository.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/repository/HubRouteRepository.java
@@ -16,4 +16,6 @@ public interface HubRouteRepository {
 	List<HubRoute> findAll();
 
 	List<HubRoute> findAllNotDeleted();
+
+	void softDeleteAll(Long deletedBy);
 }

--- a/hub/src/main/java/com/hubEleven/hub/domain/vo/Location.java
+++ b/hub/src/main/java/com/hubEleven/hub/domain/vo/Location.java
@@ -2,6 +2,7 @@ package com.hubEleven.hub.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -54,5 +55,22 @@ public class Location {
 		if (longitude < -180.0 || longitude > 180.0) {
 			throw new IllegalArgumentException("경도는 -180 이상 180 이하이어야 합니다.");
 		}
+	}
+
+	// 객채의 값 비교를 위해 추가
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Location location = (Location) o;
+		return Objects.equals(address, location.address)
+				&& Objects.equals(latitude, location.latitude)
+				&& Objects.equals(longitude, location.longitude);
+	}
+
+	// equals 오버라이드 위해 필요한 hashCode() 오버라이드
+	@Override
+	public int hashCode() {
+		return Objects.hash(address, latitude, longitude);
 	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/HubDataInitializer.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/HubDataInitializer.java
@@ -1,6 +1,6 @@
 package com.hubEleven.hub.infrastructure.config;
 
-import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.application.service.HubRouteService;
 import com.hubEleven.hub.domain.model.Hub;
 import com.hubEleven.hub.domain.repository.HubRepository;
 import java.util.List;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class HubDataInitializer implements CommandLineRunner {
 
 	private final HubRepository hubRepository;
-	private final RouteService routeService;
+	private final HubRouteService hubRouteService;
 
 	@Override
 	public void run(String... args) {
@@ -33,7 +33,7 @@ public class HubDataInitializer implements CommandLineRunner {
 			log.info("초기 허브 데이터 생성 완료");
 
 			log.info("허브 경로 생성을 시작합니다.");
-			routeService.generateAllRoutes();
+			hubRouteService.generateAllRoutes();
 			log.info("허브 경로 생성 완료");
 
 		} catch (Exception e) {
@@ -90,7 +90,7 @@ public class HubDataInitializer implements CommandLineRunner {
 		for (HubData data : hubDataList) {
 			try {
 				Hub hub =
-						Hub.create(
+						Hub.createNoEvent(
 								data.name, data.address, data.latitude, data.longitude, data.regionCode, createdBy);
 
 				hubRepository.save(hub);

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRouteRepositoryAdapter.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/HubRouteRepositoryAdapter.java
@@ -38,4 +38,11 @@ public class HubRouteRepositoryAdapter implements HubRouteRepository {
 	public List<HubRoute> findAllNotDeleted() {
 		return jpaHubRouteRepository.findAllNotDeleted();
 	}
+
+	@Override
+	public void softDeleteAll(Long deletedBy) {
+		List<HubRoute> routes = jpaHubRouteRepository.findAllNotDeleted();
+		routes.forEach(route -> route.softDelete(deletedBy));
+		jpaHubRouteRepository.saveAll(routes);
+	}
 }

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -6,11 +6,18 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
 
 	@Query("SELECT hr FROM HubRoute hr WHERE hr.deletedAt IS NULL")
 	List<HubRoute> findAllNotDeleted();
 
-	Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+	@Query(
+			"SELECT hr FROM HubRoute hr "
+					+ "WHERE hr.fromHubId = :fromHubId "
+					+ "AND hr.toHubId = :toHubId "
+					+ "AND hr.deletedAt IS NULL")
+	Optional<HubRoute> findByFromHubIdAndToHubId(
+			@Param("fromHubId") UUID fromHubId, @Param("toHubId") UUID toHubId);
 }

--- a/hub/src/main/java/com/hubEleven/hub/presentation/HubRouteController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/HubRouteController.java
@@ -1,9 +1,9 @@
 package com.hubEleven.hub.presentation;
 
-import com.hubEleven.common.response.ApiResponse;
-import com.hubEleven.common.response.ApiResponseEntity;
+import com.commonLib.common.response.ApiResponse;
+import com.commonLib.common.response.ApiResponseEntity;
 import com.hubEleven.hub.application.dto.RouteResult;
-import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.application.service.HubRouteService;
 import com.hubEleven.hub.presentation.dto.response.HubRouteResponseDto;
 import java.util.List;
 import java.util.UUID;
@@ -20,17 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HubRouteController {
 
-	private final RouteService routeService;
+	private final HubRouteService hubRouteService;
 
 	@PostMapping("/generate")
 	public ResponseEntity<ApiResponse<String>> generateAllRoutes() {
-		routeService.generateAllRoutes();
+		hubRouteService.generateAllRoutes();
 		return ApiResponseEntity.success("모든 경로 생성이 완료되었습니다.");
 	}
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<HubRouteResponseDto>>> getAllRoutes() {
-		List<RouteResult> results = routeService.getAllRoutes();
+		List<RouteResult> results = hubRouteService.getAllRoutes();
 		List<HubRouteResponseDto> response = HubRouteResponseDto.fromList(results);
 		return ApiResponseEntity.success(response);
 	}
@@ -38,7 +38,7 @@ public class HubRouteController {
 	@GetMapping("/search")
 	public ResponseEntity<ApiResponse<HubRouteResponseDto>> searchRoute(
 			@RequestParam UUID fromHubId, @RequestParam UUID toHubId) {
-		RouteResult result = routeService.findRoute(fromHubId, toHubId);
+		RouteResult result = hubRouteService.findRoute(fromHubId, toHubId);
 		HubRouteResponseDto response = HubRouteResponseDto.from(result);
 		return ApiResponseEntity.success(response);
 	}

--- a/hub/src/main/java/com/hubEleven/hub/presentation/internal/InternalHubRouteController.java
+++ b/hub/src/main/java/com/hubEleven/hub/presentation/internal/InternalHubRouteController.java
@@ -1,9 +1,9 @@
 package com.hubEleven.hub.presentation.internal;
 
-import com.hubEleven.common.response.ApiResponse;
-import com.hubEleven.common.response.ApiResponseEntity;
+import com.commonLib.common.response.ApiResponse;
+import com.commonLib.common.response.ApiResponseEntity;
 import com.hubEleven.hub.application.dto.RouteResult;
-import com.hubEleven.hub.application.service.RouteService;
+import com.hubEleven.hub.application.service.HubRouteService;
 import com.hubEleven.hub.presentation.dto.response.HubRouteResponseDto;
 import java.util.List;
 import java.util.UUID;
@@ -19,11 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class InternalHubRouteController {
 
-	private final RouteService routeService;
+	private final HubRouteService hubRouteService;
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<HubRouteResponseDto>>> getAllRoutes() {
-		List<RouteResult> results = routeService.getAllRoutes();
+		List<RouteResult> results = hubRouteService.getAllRoutes();
 		List<HubRouteResponseDto> response = HubRouteResponseDto.fromList(results);
 		return ApiResponseEntity.success(response);
 	}
@@ -31,7 +31,7 @@ public class InternalHubRouteController {
 	@GetMapping("/search")
 	public ResponseEntity<ApiResponse<HubRouteResponseDto>> searchRoute(
 			@RequestParam UUID fromHubId, @RequestParam UUID toHubId) {
-		RouteResult result = routeService.findRoute(fromHubId, toHubId);
+		RouteResult result = hubRouteService.findRoute(fromHubId, toHubId);
 		HubRouteResponseDto response = HubRouteResponseDto.from(result);
 		return ApiResponseEntity.success(response);
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
#60 

### 🪄작업 내용 
- Hub 엔티티에서 위치 변경, 생성, 삭제 시 도메인 이벤트를 발행하는 구조 구현
- 도메인 이벤트 3종 추가 (HubCreatedEvent, HubLocationChangedEvent, HubDeletedEvent)
- Hub의 Location 변경 감지를 위해 Location Value Object에 equals/hashCode 구현
- 도메인 이벤트 발행 시 Spring Data JPA의 @DomainEvents 패턴 적용
- 이벤트 핸들러에서 Hub 변경 감지 시 전체 HubRoute를 soft delete 후 재계산
- 별도 트랜잭션 분리로 안정성 확보
- Hub 초기화 시에는 이벤트 미발행하여 중복 경로 생성 방지

### ✏️리뷰 요청
- 가독성이나 흐름이 괜찮은지 리뷰 부탁드립니다!