### PR TITLE
[feat] HubEleven 전체 서비스 모니터링 연동

### DIFF
--- a/company/build.gradle
+++ b/company/build.gradle
@@ -46,11 +46,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 
 }
 

--- a/company/src/main/resources/application-monitor.yml
+++ b/company/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/company/src/main/resources/application-monitor.yml
+++ b/company/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/company/src/main/resources/application.yml
+++ b/company/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
 
 springdoc:
   api-docs:

--- a/company/src/main/resources/logback-spring.xml
+++ b/company/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -56,11 +56,18 @@ dependencies {
     testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
+
     implementation 'com.github.Doritosch:commonLib:1.0.5'
 
     //맥에서 webflux

--- a/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
+++ b/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
 				.addFilterAt(headerAuthFilter, SecurityWebFiltersOrder.AUTHENTICATION)
 				.authorizeExchange(
 						exchange -> {
+							exchange.pathMatchers("/actuator/**").permitAll();
 							// PUBLIC_PATHS 설정은 Delivery Service에 필요하다면 추가
 							exchange.anyExchange().authenticated(); // 나머지 모든 요청은 인증 필요
 						})

--- a/delivery/src/main/resources/application-monitor.yml
+++ b/delivery/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/delivery/src/main/resources/application-monitor.yml
+++ b/delivery/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/delivery/src/main/resources/application.yml
+++ b/delivery/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/hubEleven?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/delivery/src/main/resources/logback-spring.xml
+++ b/delivery/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/gateWay/build.gradle
+++ b/gateWay/build.gradle
@@ -43,11 +43,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 }
 
 dependencyManagement {

--- a/gateWay/src/main/resources/application-monitor.yml
+++ b/gateWay/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/gateWay/src/main/resources/application-monitor.yml
+++ b/gateWay/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/gateWay/src/main/resources/application.yml
+++ b/gateWay/src/main/resources/application.yml
@@ -5,6 +5,9 @@ eureka:
     service-url:
       defaultZone: http://localhost:8761/eureka
 spring:
+  profiles:
+    include:
+      - monitor
   cloud:
     gateway:
       routes:

--- a/gateWay/src/main/resources/logback-spring.xml
+++ b/gateWay/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -43,11 +43,17 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.github.Doritosch:commonLib:1.0.5'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 }
 
 dependencyManagement {

--- a/hub/src/main/resources/application-monitor.yml
+++ b/hub/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/hub/src/main/resources/application-monitor.yml
+++ b/hub/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
   cache:
     type: simple  # simple = ConcurrentMapCacheManager / redis = redis 사용
     cache-names:

--- a/hub/src/main/resources/logback-spring.xml
+++ b/hub/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -48,11 +48,18 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
+
 }
 
 dependencyManagement {

--- a/notification/src/main/resources/application-monitor.yml
+++ b/notification/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/notification/src/main/resources/application-monitor.yml
+++ b/notification/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -15,3 +15,4 @@ spring:
     include:
       - eureka
       - swagger
+      - monitor

--- a/notification/src/main/resources/logback-spring.xml
+++ b/notification/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -45,11 +45,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 }
 
 dependencyManagement {

--- a/order/src/main/resources/application-monitor.yml
+++ b/order/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/order/src/main/resources/application-monitor.yml
+++ b/order/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
 
 eureka:
   client:

--- a/order/src/main/resources/logback-spring.xml
+++ b/order/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -44,11 +44,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 
 }
 

--- a/product/src/main/resources/application-monitor.yml
+++ b/product/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/product/src/main/resources/application-monitor.yml
+++ b/product/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
 
 eureka:
   client:

--- a/product/src/main/resources/logback-spring.xml
+++ b/product/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -46,11 +46,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // zipkin
+    // actuator + metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // tracing (brave + zipkin)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // logging -> loki (push)
+    implementation 'com.github.loki4j:loki-logback-appender:2.0.1'
 
 }
 

--- a/user/src/main/java/com/hubEleven/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/hubEleven/user/infrastructure/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 		return http.securityMatcher(
 						"/v1/user/login",
 						"/v1/user/signup",
+						"/actuator/**",
 						"/api-docs/**",
 						"/v3/api-docs/**",
 						"/swagger-ui/**",

--- a/user/src/main/resources/application-monitor.yml
+++ b/user/src/main/resources/application-monitor.yml
@@ -1,0 +1,17 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      instance: ${spring.cloud.client.hostname}:${server.port}
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/user/src/main/resources/application-monitor.yml
+++ b/user/src/main/resources/application-monitor.yml
@@ -13,5 +13,3 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       discovery:
         enabled: true
         service-id: config
+  profiles:
+    include:
+      - monitor
 
 management:
   endpoints:

--- a/user/src/main/resources/logback-spring.xml
+++ b/user/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty name="HOSTNAME" source="HOSTNAME" defaultValue="localhost"/>
+    <springProperty name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-}] [%X{spanId:-}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+
+        <labels>
+            app=${SERVICE_NAME}
+            host=${HOSTNAME}
+        </labels>
+
+        <structuredMetadata>
+            level=%level
+            logger=%logger
+            thread=%thread
+            traceId=%X{traceId:-}
+            spanId=%X{spanId:-}
+        </structuredMetadata>
+
+        <message>
+            <pattern>%msg%n</pattern>
+        </message>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+    <logger name="com.hubEleven" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #103 

<br>

## 📌 개요
- 전체 서비스에 모니터링 스택(Prometheus/Grafana) 및 로그 수집(Loki), 분산 트레이싱(Zipkin)을 연동했습니다.
- 각 서비스에 Actuator + Prometheus Registry를 적용하여 /actuator/prometheus로 메트릭을 노출하고, Logback을 통해 Loki로 로그를 전송하도록 구성했습니다.
- 연동 확인 중 delivery/user 서비스는 Spring Security 설정으로 Actuator 접근이 차단되어 Prometheus Targets가 DOWN(401) 상태였고, /actuator/** 인증 예외 처리로 수집 가능하도록 조치했습니다.

<br>

## 🔁 변경 사항
1) Metrics (Prometheus)
전 서비스에 Actuator 및 Prometheus Registry 의존성 추가
/actuator/prometheus 엔드포인트 노출 설정 추가(프로파일/설정 파일 적용)

2) Logs (Loki)
전 서비스에 Loki Logback Appender 적용
logback-spring.xml 추가/수정하여 Loki로 로그 push 구성
서비스명/호스트 등 라벨 기반으로 로그 식별 가능하도록 설정

3) delivery/user 401 이슈 해결
원인: Spring Security 설정으로 Actuator 접근이 막혀 Prometheus가 메트릭을 수집하지 못함
해결: delivery, user에서 /actuator/**를 인증 예외(permitAll) 처리하여 Prometheus 수집 가능하도록 변경
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.

