### PR TITLE
[feat] 전체 서비스에 OpenApiConfig 추가

### DIFF
--- a/company/src/main/java/com/hubEleven/company/infrastructure/client/HubClient.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/client/HubClient.java
@@ -1,6 +1,6 @@
 package com.hubEleven.company.infrastructure.client;
 
-import com.hubEleven.company.infrastructure.configuration.FeignConfig;
+import com.hubEleven.company.infrastructure.config.FeignConfig;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/company/src/main/java/com/hubEleven/company/infrastructure/client/SlackClient.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/client/SlackClient.java
@@ -1,6 +1,6 @@
 package com.hubEleven.company.infrastructure.client;
 
-import com.hubEleven.company.infrastructure.configuration.FeignConfig;
+import com.hubEleven.company.infrastructure.config.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/company/src/main/java/com/hubEleven/company/infrastructure/config/CompanyJpaConfig.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/config/CompanyJpaConfig.java
@@ -1,4 +1,4 @@
-package com.hubEleven.company.infrastructure.configuration;
+package com.hubEleven.company.infrastructure.config;
 
 import java.util.Optional;
 import org.springframework.context.annotation.Bean;

--- a/company/src/main/java/com/hubEleven/company/infrastructure/config/FeignConfig.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/config/FeignConfig.java
@@ -1,4 +1,4 @@
-package com.hubEleven.company.infrastructure.configuration;
+package com.hubEleven.company.infrastructure.config;
 
 import feign.RequestInterceptor;
 import org.springframework.context.annotation.Bean;

--- a/company/src/main/java/com/hubEleven/company/infrastructure/config/OpenApiConfig.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/config/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.hubEleven.company.infrastructure.configuration;
+package com.hubEleven.company.infrastructure.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/company/src/main/java/com/hubEleven/company/infrastructure/config/OpenApiConfig.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/config/OpenApiConfig.java
@@ -32,4 +32,3 @@ public class OpenApiConfig {
 												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
 	}
 }
-

--- a/company/src/main/java/com/hubEleven/company/infrastructure/configuration/OpenApiConfig.java
+++ b/company/src/main/java/com/hubEleven/company/infrastructure/configuration/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.hubEleven.company.infrastructure.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.info(
+						new Info()
+								.title("Company Service API")
+								.version("1.0")
+								.description("Company Service API with JWT Authentication"))
+				.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+				.components(
+						new Components()
+								.addSecuritySchemes(
+										"Bearer Authentication",
+										new SecurityScheme()
+												.name("Bearer Authentication")
+												.type(SecurityScheme.Type.HTTP)
+												.scheme("bearer")
+												.bearerFormat("JWT")
+												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
+	}
+}
+

--- a/delivery/src/main/java/com/hubEleven/delivery/infrastructure/config/OpenApiConfig.java
+++ b/delivery/src/main/java/com/hubEleven/delivery/infrastructure/config/OpenApiConfig.java
@@ -32,4 +32,3 @@ public class OpenApiConfig {
 												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
 	}
 }
-

--- a/delivery/src/main/java/com/hubEleven/delivery/infrastructure/config/OpenApiConfig.java
+++ b/delivery/src/main/java/com/hubEleven/delivery/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.hubEleven.delivery.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.info(
+						new Info()
+								.title("Delivery Service API")
+								.version("1.0")
+								.description("Delivery Service API with JWT Authentication"))
+				.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+				.components(
+						new Components()
+								.addSecuritySchemes(
+										"Bearer Authentication",
+										new SecurityScheme()
+												.name("Bearer Authentication")
+												.type(SecurityScheme.Type.HTTP)
+												.scheme("bearer")
+												.bearerFormat("JWT")
+												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
+	}
+}
+

--- a/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
+++ b/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
@@ -14,13 +14,27 @@ public class SecurityConfig {
 	public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
 		HeaderAuthenticationFilter headerAuthFilter = new HeaderAuthenticationFilter();
 
-		return http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+		return http
+				.csrf(ServerHttpSecurity.CsrfSpec::disable)
 				// .oauth2ResourceServer(oauth2 -> oauth2.disable()) // 의존성 제거했으면 이 줄 불필요
+
+				// CORS preflight(OPTIONS) 처리를 위해 CORS 활성화 (필요 시 CorsWebFilter/설정 추가)
+				.cors(org.springframework.security.config.Customizer.withDefaults())
 
 				// 2. 커스텀 필터를 AuthenticationWebFilter 이전에 추가
 				.addFilterAt(headerAuthFilter, SecurityWebFiltersOrder.AUTHENTICATION)
 				.authorizeExchange(
 						exchange -> {
+							// 브라우저의 preflight(OPTIONS)는 Authorization 없이 오므로 먼저 허용
+							exchange.pathMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll();
+
+							// Swagger / OpenAPI 문서 및 UI는 인증 없이 접근 가능
+							exchange.pathMatchers(
+									"/swagger-ui/**",
+									"/v3/api-docs/**",
+									"/swagger-ui.html"
+							).permitAll();
+
 							// PUBLIC_PATHS 설정은 Delivery Service에 필요하다면 추가
 							exchange.anyExchange().authenticated(); // 나머지 모든 요청은 인증 필요
 						})

--- a/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
+++ b/delivery/src/main/java/com/hubEleven/delivery/infrastructure/security/SecurityConfig.java
@@ -14,8 +14,7 @@ public class SecurityConfig {
 	public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
 		HeaderAuthenticationFilter headerAuthFilter = new HeaderAuthenticationFilter();
 
-		return http
-				.csrf(ServerHttpSecurity.CsrfSpec::disable)
+		return http.csrf(ServerHttpSecurity.CsrfSpec::disable)
 				// .oauth2ResourceServer(oauth2 -> oauth2.disable()) // 의존성 제거했으면 이 줄 불필요
 
 				// CORS preflight(OPTIONS) 처리를 위해 CORS 활성화 (필요 시 CorsWebFilter/설정 추가)
@@ -29,11 +28,9 @@ public class SecurityConfig {
 							exchange.pathMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll();
 
 							// Swagger / OpenAPI 문서 및 UI는 인증 없이 접근 가능
-							exchange.pathMatchers(
-									"/swagger-ui/**",
-									"/v3/api-docs/**",
-									"/swagger-ui.html"
-							).permitAll();
+							exchange
+									.pathMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
+									.permitAll();
 
 							// PUBLIC_PATHS 설정은 Delivery Service에 필요하다면 추가
 							exchange.anyExchange().authenticated(); // 나머지 모든 요청은 인증 필요

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/OpenApiConfig.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/OpenApiConfig.java
@@ -32,4 +32,3 @@ public class OpenApiConfig {
 												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
 	}
 }
-

--- a/hub/src/main/java/com/hubEleven/hub/infrastructure/config/OpenApiConfig.java
+++ b/hub/src/main/java/com/hubEleven/hub/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.hubEleven.hub.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.info(
+						new Info()
+								.title("Hub Service API")
+								.version("1.0")
+								.description("Hub Service API with JWT Authentication"))
+				.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+				.components(
+						new Components()
+								.addSecuritySchemes(
+										"Bearer Authentication",
+										new SecurityScheme()
+												.name("Bearer Authentication")
+												.type(SecurityScheme.Type.HTTP)
+												.scheme("bearer")
+												.bearerFormat("JWT")
+												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
+	}
+}
+

--- a/order/src/main/java/com/hubEleven/order/infrastructure/configuration/OpenApiConfig.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/configuration/OpenApiConfig.java
@@ -32,4 +32,3 @@ public class OpenApiConfig {
 												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
 	}
 }
-

--- a/order/src/main/java/com/hubEleven/order/infrastructure/configuration/OpenApiConfig.java
+++ b/order/src/main/java/com/hubEleven/order/infrastructure/configuration/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.hubEleven.order.infrastructure.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.info(
+						new Info()
+								.title("Order Service API")
+								.version("1.0")
+								.description("Order Service API with JWT Authentication"))
+				.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+				.components(
+						new Components()
+								.addSecuritySchemes(
+										"Bearer Authentication",
+										new SecurityScheme()
+												.name("Bearer Authentication")
+												.type(SecurityScheme.Type.HTTP)
+												.scheme("bearer")
+												.bearerFormat("JWT")
+												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
+	}
+}
+

--- a/product/src/main/java/com/hubEleven/product/infrastructure/configuration/OpenApiConfig.java
+++ b/product/src/main/java/com/hubEleven/product/infrastructure/configuration/OpenApiConfig.java
@@ -32,4 +32,3 @@ public class OpenApiConfig {
 												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
 	}
 }
-

--- a/product/src/main/java/com/hubEleven/product/infrastructure/configuration/OpenApiConfig.java
+++ b/product/src/main/java/com/hubEleven/product/infrastructure/configuration/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.hubEleven.product.infrastructure.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.info(
+						new Info()
+								.title("Product Service API")
+								.version("1.0")
+								.description("Product Service API with JWT Authentication"))
+				.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+				.components(
+						new Components()
+								.addSecuritySchemes(
+										"Bearer Authentication",
+										new SecurityScheme()
+												.name("Bearer Authentication")
+												.type(SecurityScheme.Type.HTTP)
+												.scheme("bearer")
+												.bearerFormat("JWT")
+												.description("JWT 토큰을 입력하세요 (Bearer 제외)")));
+	}
+}
+


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #107 

<br>

## 📌 개요
- Swagger(OpenAPI)에 JWT Bearer 인증 스키마를 추가했습니다.
- Swagger UI에서 Authorize 버튼을 통해 토큰을 입력하고, 인증이 필요한 API를 테스트할 수 있도록 설정했습니다.

<br>

## 🔁 변경 사항
- OpenApiConfig 추가
OpenAPI 기본 정보(title/version/description) 설정
Bearer Authentication SecurityScheme(HTTP bearer, JWT) 등록 

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.

