### PR TITLE
[feat] company-service 로깅 작업

### DIFF
--- a/company/src/main/java/com/hubEleven/company/application/service/impl/CompanyServiceImpl.java
+++ b/company/src/main/java/com/hubEleven/company/application/service/impl/CompanyServiceImpl.java
@@ -39,9 +39,9 @@ public class CompanyServiceImpl implements CompanyService {
 				Company.create(cmd.hubId(), cmd.name(), cmd.type(), cmd.slackId(), cmd.address());
 		Company saved = companyRepository.save(company);
 
-		log.info("업체 생성 성공 companyId={} hubId={} name={}", saved.getCompanyId(), cmd.hubId(), cmd.name());
+		log.info(
+				"업체 생성 성공 companyId={} hubId={} name={}", saved.getCompanyId(), cmd.hubId(), cmd.name());
 		return CompanyResult.from(saved);
-
 	}
 
 	@Transactional
@@ -61,7 +61,11 @@ public class CompanyServiceImpl implements CompanyService {
 		company.changeType(cmd.type());
 		company.update(cmd.name(), cmd.address(), cmd.slackId());
 
-		log.info("업체 수정 성공 companyId={} hubId={} name={}", company.getCompanyId(), company.getHubId(), cmd.name());
+		log.info(
+				"업체 수정 성공 companyId={} hubId={} name={}",
+				company.getCompanyId(),
+				company.getHubId(),
+				cmd.name());
 		return CompanyResult.from(company);
 	}
 
@@ -81,14 +85,19 @@ public class CompanyServiceImpl implements CompanyService {
 	@Override
 	public CommonPageResponse<CompanyResult> searchCompany(
 			SearchCompanyCommand cmd, CommonPageRequest pageReq) {
-		log.debug("업체 검색 hubId={} name={} type={} status={} page={} size={}",
-				cmd.hubId(), cmd.name(), cmd.type(), cmd.status(),
-				pageReq.page(), pageReq.size());
+		log.debug(
+				"업체 검색 hubId={} name={} type={} status={} page={} size={}",
+				cmd.hubId(),
+				cmd.name(),
+				cmd.type(),
+				cmd.status(),
+				pageReq.page(),
+				pageReq.size());
 
 		var page = companyRepository.search(cmd, pageReq.toPageable());
 
-		log.debug("업체 검색 결과 totalElements={} totalPages={}",
-				page.getTotalElements(), page.getTotalPages());
+		log.debug(
+				"업체 검색 결과 totalElements={} totalPages={}", page.getTotalElements(), page.getTotalPages());
 		return PagingUtils.convert(page, CompanyResult::from);
 	}
 
@@ -105,7 +114,11 @@ public class CompanyServiceImpl implements CompanyService {
 
 		company.changeStatus(cmd.status());
 
-		log.info("업체 상태 변경 성공 companyId={} hubId={} status={}", company.getCompanyId(), company.getHubId(), cmd.status());
+		log.info(
+				"업체 상태 변경 성공 companyId={} hubId={} status={}",
+				company.getCompanyId(),
+				company.getHubId(),
+				cmd.status());
 		return CompanyResult.from(company);
 	}
 
@@ -122,7 +135,6 @@ public class CompanyServiceImpl implements CompanyService {
 		company.delete(userId);
 		companyRepository.save(company);
 
-		log.info("업체 삭제 성공 companyId={} hubId={}",
-				company.getCompanyId(), company.getHubId());
+		log.info("업체 삭제 성공 companyId={} hubId={}", company.getCompanyId(), company.getHubId());
 	}
 }

--- a/company/src/main/java/com/hubEleven/company/application/service/impl/CompanyServiceImpl.java
+++ b/company/src/main/java/com/hubEleven/company/application/service/impl/CompanyServiceImpl.java
@@ -37,13 +37,17 @@ public class CompanyServiceImpl implements CompanyService {
 
 		Company company =
 				Company.create(cmd.hubId(), cmd.name(), cmd.type(), cmd.slackId(), cmd.address());
-		return CompanyResult.from(companyRepository.save(company));
+		Company saved = companyRepository.save(company);
+
+		log.info("업체 생성 성공 companyId={} hubId={} name={}", saved.getCompanyId(), cmd.hubId(), cmd.name());
+		return CompanyResult.from(saved);
+
 	}
 
 	@Transactional
 	@Override
 	public CompanyResult updateCompany(UpdateCompanyCommand cmd, Long userId, String userRole) {
-		var company =
+		Company company =
 				companyRepository
 						.findById(cmd.companyId())
 						.orElseThrow(() -> new GlobalException(CompanyErrorCode.COMPANY_NOT_FOUND));
@@ -56,13 +60,17 @@ public class CompanyServiceImpl implements CompanyService {
 
 		company.changeType(cmd.type());
 		company.update(cmd.name(), cmd.address(), cmd.slackId());
+
+		log.info("업체 수정 성공 companyId={} hubId={} name={}", company.getCompanyId(), company.getHubId(), cmd.name());
 		return CompanyResult.from(company);
 	}
 
 	@Transactional(readOnly = true)
 	@Override
 	public CompanyResult getCompany(UUID companyId) {
-		var company =
+		log.debug("업체 조회 companyId={}", companyId);
+
+		Company company =
 				companyRepository
 						.findById(companyId)
 						.orElseThrow(() -> new GlobalException(CompanyErrorCode.COMPANY_NOT_FOUND));
@@ -73,14 +81,21 @@ public class CompanyServiceImpl implements CompanyService {
 	@Override
 	public CommonPageResponse<CompanyResult> searchCompany(
 			SearchCompanyCommand cmd, CommonPageRequest pageReq) {
+		log.debug("업체 검색 hubId={} name={} type={} status={} page={} size={}",
+				cmd.hubId(), cmd.name(), cmd.type(), cmd.status(),
+				pageReq.page(), pageReq.size());
+
 		var page = companyRepository.search(cmd, pageReq.toPageable());
+
+		log.debug("업체 검색 결과 totalElements={} totalPages={}",
+				page.getTotalElements(), page.getTotalPages());
 		return PagingUtils.convert(page, CompanyResult::from);
 	}
 
 	@Transactional
 	@Override
 	public CompanyResult changeStatus(ChangeCompanyStatusCommand cmd, Long userId, String userRole) {
-		var company =
+		Company company =
 				companyRepository
 						.findById(cmd.companyId())
 						.orElseThrow(() -> new GlobalException(CompanyErrorCode.COMPANY_NOT_FOUND));
@@ -89,13 +104,15 @@ public class CompanyServiceImpl implements CompanyService {
 				company.getHubId(), company.getCompanyId(), userId, userRole);
 
 		company.changeStatus(cmd.status());
+
+		log.info("업체 상태 변경 성공 companyId={} hubId={} status={}", company.getCompanyId(), company.getHubId(), cmd.status());
 		return CompanyResult.from(company);
 	}
 
 	@Transactional
 	@Override
 	public void deleteCompany(UUID companyId, Long userId, String userRole) {
-		var company =
+		Company company =
 				companyRepository
 						.findById(companyId)
 						.orElseThrow(() -> new GlobalException(CompanyErrorCode.COMPANY_NOT_FOUND));
@@ -104,5 +121,8 @@ public class CompanyServiceImpl implements CompanyService {
 
 		company.delete(userId);
 		companyRepository.save(company);
+
+		log.info("업체 삭제 성공 companyId={} hubId={}",
+				company.getCompanyId(), company.getHubId());
 	}
 }

--- a/company/src/main/java/com/hubEleven/company/application/validator/CompanyValidator.java
+++ b/company/src/main/java/com/hubEleven/company/application/validator/CompanyValidator.java
@@ -28,7 +28,7 @@ public class CompanyValidator {
 		} catch (FeignException.NotFound e) {
 			throw new GlobalException(CompanyErrorCode.HUB_NOT_FOUND);
 		} catch (FeignException e) {
-			log.error("hub.get fail hubId={} status={}", hubId, e.status(), e);
+			log.error("hub 정보 불러올 수 없음 hubId={} status={}", hubId, e.status(), e);
 			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		}
 	}
@@ -44,7 +44,7 @@ public class CompanyValidator {
 
 		UUID companyId = user.companyId();
 		if (companyId == null) {
-			log.debug("user.companyId is null userId={}", userId);
+			log.debug("사용자의 companyId가 null userId={}", userId);
 			return null;
 		}
 
@@ -60,10 +60,10 @@ public class CompanyValidator {
 		try {
 			return userClient.getUser(userId, userId, userRole);
 		} catch (FeignException e) {
-			log.error("user.get fail userId={} role={} status={}", userId, userRole, e.status(), e);
+			log.error("사용자 정보 불러오기 실패 userId={} role={} status={}", userId, userRole, e.status(), e);
 			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		} catch (Exception e) {
-			log.error("user.get fail userId={} role={}", userId, userRole, e);
+			log.error("사용자 정보 불러오기 실패 userId={} role={}", userId, userRole, e);
 			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		}
 	}

--- a/company/src/main/java/com/hubEleven/company/application/validator/CompanyValidator.java
+++ b/company/src/main/java/com/hubEleven/company/application/validator/CompanyValidator.java
@@ -7,6 +7,7 @@ import com.hubEleven.company.domain.repository.CompanyRepository;
 import com.hubEleven.company.exception.CompanyErrorCode;
 import com.hubEleven.company.infrastructure.client.HubClient;
 import com.hubEleven.company.infrastructure.client.UserClient;
+import feign.FeignException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,9 +25,10 @@ public class CompanyValidator {
 	public void assertHubExists(UUID hubId) {
 		try {
 			hubClient.getHub(hubId);
-		} catch (feign.FeignException.NotFound e) {
+		} catch (FeignException.NotFound e) {
 			throw new GlobalException(CompanyErrorCode.HUB_NOT_FOUND);
-		} catch (feign.FeignException e) {
+		} catch (FeignException e) {
+			log.error("hub.get fail hubId={} status={}", hubId, e.status(), e);
 			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		}
 	}
@@ -38,27 +40,31 @@ public class CompanyValidator {
 			return null;
 		}
 
-		try {
-			UserClient.UserDTO user = userClient.getUser(userId, userId, userRole);
-			if (user.companyId() == null) {
-				log.warn("사용자의 companyId가 null입니다. userId: {}", userId);
-				return null;
-			}
+		UserClient.UserDTO user = getUserOrThrow(userId, userRole);
 
-			return companyRepository.findById(user.companyId()).map(Company::getHubId).orElse(null);
-		} catch (Exception e) {
-			log.error("사용자 hubId 조회 실패. userId: {}, error: {}", userId, e.getMessage());
+		UUID companyId = user.companyId();
+		if (companyId == null) {
+			log.debug("user.companyId is null userId={}", userId);
 			return null;
 		}
+
+		return companyRepository.findById(companyId).map(Company::getHubId).orElse(null);
 	}
 
 	public UUID getUserCompanyId(Long userId, String userRole) {
+		UserClient.UserDTO user = getUserOrThrow(userId, userRole);
+		return user.companyId();
+	}
+
+	private UserClient.UserDTO getUserOrThrow(Long userId, String userRole) {
 		try {
-			UserClient.UserDTO user = userClient.getUser(userId, userId, userRole);
-			return user.companyId();
+			return userClient.getUser(userId, userId, userRole);
+		} catch (FeignException e) {
+			log.error("user.get fail userId={} role={} status={}", userId, userRole, e.status(), e);
+			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		} catch (Exception e) {
-			log.error("사용자 companyId 조회 실패. userId: {}, error: {}", userId, e.getMessage());
-			return null;
+			log.error("user.get fail userId={} role={}", userId, userRole, e);
+			throw new GlobalException(ErrorCode.SERVER_ERROR);
 		}
 	}
 
@@ -78,13 +84,13 @@ public class CompanyValidator {
 			throw new GlobalException(CompanyErrorCode.UNAUTHORIZED);
 		}
 
-		String normalizedRole = normalizeRole(userRole);
+		String role = normalizeRole(userRole);
 
-		if ("MASTER".equals(normalizedRole)) {
+		if ("MASTER".equals(role)) {
 			return;
 		}
 
-		if ("HUB_MANAGER".equals(normalizedRole)) {
+		if ("HUB_MANAGER".equals(role)) {
 			UUID userHubId = getUserHubId(userId, userRole);
 			if (hubId != null && hubId.equals(userHubId)) {
 				return;
@@ -99,20 +105,20 @@ public class CompanyValidator {
 			throw new GlobalException(CompanyErrorCode.UNAUTHORIZED);
 		}
 
-		String normalizedRole = normalizeRole(userRole);
+		String role = normalizeRole(userRole);
 
-		if ("MASTER".equals(normalizedRole)) {
+		if ("MASTER".equals(role)) {
 			return;
 		}
 
-		if ("HUB_MANAGER".equals(normalizedRole)) {
+		if ("HUB_MANAGER".equals(role)) {
 			UUID userHubId = getUserHubId(userId, userRole);
 			if (hubId != null && hubId.equals(userHubId)) {
 				return;
 			}
 		}
 
-		if ("COMPANY_MANAGER".equals(normalizedRole)) {
+		if ("COMPANY_MANAGER".equals(role)) {
 			UUID userCompanyId = getUserCompanyId(userId, userRole);
 			if (companyId != null && companyId.equals(userCompanyId)) {
 				return;
@@ -127,13 +133,13 @@ public class CompanyValidator {
 			throw new GlobalException(CompanyErrorCode.UNAUTHORIZED);
 		}
 
-		String normalizedRole = normalizeRole(userRole);
+		String role = normalizeRole(userRole);
 
-		if ("MASTER".equals(normalizedRole)) {
+		if ("MASTER".equals(role)) {
 			return;
 		}
 
-		if ("HUB_MANAGER".equals(normalizedRole)) {
+		if ("HUB_MANAGER".equals(role)) {
 			UUID userHubId = getUserHubId(userId, userRole);
 			if (hubId != null && hubId.equals(userHubId)) {
 				return;

--- a/company/src/main/java/com/hubEleven/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/hubEleven/company/presentation/controller/CompanyController.java
@@ -95,8 +95,14 @@ public class CompanyController {
 			@RequestParam(required = false) CompanyType type,
 			@RequestParam(required = false) CompanyStatus status) {
 
-		log.debug("업체 목록/검색 요청 - hubId:{}, name:{}, type:{}, status:{}, page: {}, size: {}",
-				hubId, name, type, status, pageReq.page(), pageReq.size());
+		log.debug(
+				"업체 목록/검색 요청 - hubId:{}, name:{}, type:{}, status:{}, page: {}, size: {}",
+				hubId,
+				name,
+				type,
+				status,
+				pageReq.page(),
+				pageReq.size());
 
 		var page =
 				companyService.searchCompany(new SearchCompanyCommand(hubId, name, type, status), pageReq);
@@ -111,8 +117,8 @@ public class CompanyController {
 						page.first(),
 						page.last());
 
-		log.debug("업체 목록/검색 성공 - totalElements: {}, totalPages: {}",
-				page.totalElements(), page.totalPages());
+		log.debug(
+				"업체 목록/검색 성공 - totalElements: {}, totalPages: {}", page.totalElements(), page.totalPages());
 		return ApiResponseEntity.success(mapped);
 	}
 

--- a/company/src/main/java/com/hubEleven/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/hubEleven/company/presentation/controller/CompanyController.java
@@ -21,9 +21,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "Company", description = "업체 API")
 @RestController
 @RequiredArgsConstructor
@@ -39,12 +41,16 @@ public class CompanyController {
 			@RequestHeader("X-User-Id") Long userId,
 			@RequestHeader("X-User-Role") String userRole) {
 
+		log.info("업체 생성 요청 - hubId:{}, name:{}", req.hubId(), req.name());
+
 		CompanyResult result =
 				companyService.createCompany(
 						new CreateCompanyCommand(
 								req.hubId(), req.name(), req.type(), req.slackId(), req.address()),
 						userId,
 						userRole);
+
+		log.info("업체 생성 성공 - companyId:{}", result.companyId());
 		return ApiResponseEntity.success(CompanyResponse.from(result));
 	}
 
@@ -56,19 +62,27 @@ public class CompanyController {
 			@RequestHeader("X-User-Id") Long userId,
 			@RequestHeader("X-User-Role") String userRole) {
 
+		log.info("업체 수정 요청 - companyId:{}, name:{}", companyId, req.name());
+
 		CompanyResult result =
 				companyService.updateCompany(
 						new UpdateCompanyCommand(
 								companyId, req.name(), req.type(), req.slackId(), req.address()),
 						userId,
 						userRole);
+
+		log.info("업체 수정 성공 - companyId:{}, name:{}", companyId, req.name());
 		return ApiResponseEntity.success(CompanyResponse.from(result));
 	}
 
 	@Operation(summary = "업체 단건 조회 API", description = "업체 ID로 업체를 조회한다.")
 	@GetMapping("/{companyId}")
 	public ResponseEntity<ApiResponse<CompanyResponse>> getCompany(@PathVariable UUID companyId) {
+		log.debug("업체 단건 조회 요청 - companyId:{}", companyId);
+
 		CompanyResult dto = companyService.getCompany(companyId);
+
+		log.debug("업체 단건 조회 성공 - companyId:{}", companyId);
 		return ApiResponseEntity.success(CompanyResponse.from(dto));
 	}
 
@@ -80,6 +94,9 @@ public class CompanyController {
 			@RequestParam(required = false) String name,
 			@RequestParam(required = false) CompanyType type,
 			@RequestParam(required = false) CompanyStatus status) {
+
+		log.debug("업체 목록/검색 요청 - hubId:{}, name:{}, type:{}, status:{}, page: {}, size: {}",
+				hubId, name, type, status, pageReq.page(), pageReq.size());
 
 		var page =
 				companyService.searchCompany(new SearchCompanyCommand(hubId, name, type, status), pageReq);
@@ -93,6 +110,9 @@ public class CompanyController {
 						page.totalPages(),
 						page.first(),
 						page.last());
+
+		log.debug("업체 목록/검색 성공 - totalElements: {}, totalPages: {}",
+				page.totalElements(), page.totalPages());
 		return ApiResponseEntity.success(mapped);
 	}
 
@@ -104,20 +124,28 @@ public class CompanyController {
 			@RequestHeader("X-User-Id") Long userId,
 			@RequestHeader("X-User-Role") String userRole) {
 
+		log.info("업체 상태 변경 요청 - companyId:{} status:{}", companyId, req.status());
+
 		CompanyResult result =
 				companyService.changeStatus(
 						new ChangeCompanyStatusCommand(companyId, req.status()), userId, userRole);
+
+		log.info("업체 상태 변경 성공 - companyId:{} status:{}", companyId, req.status());
 		return ApiResponseEntity.success(CompanyResponse.from(result));
 	}
 
 	@Operation(summary = "업체 삭제 API", description = "업체를 삭제한다.")
-	@DeleteMapping("{companyId}")
+	@DeleteMapping("/{companyId}")
 	public ResponseEntity<ApiResponse<Object>> deleteCompany(
 			@PathVariable UUID companyId,
 			@RequestHeader("X-User-Id") Long userId,
 			@RequestHeader("X-User-Role") String userRole) {
 
+		log.info("업체 삭제 요청 - companyId: {}", companyId);
+
 		companyService.deleteCompany(companyId, userId, userRole);
+
+		log.info("업체 삭제 성공 - companyId: {}", companyId);
 		return ApiResponseEntity.success(null);
 	}
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #119 

<br>

## 📌 개요
- Company 도메인의 Controller/Service/Validator에 로깅을 적용했습니다.
- @Slf4j 기반으로 로깅을 통일하고, 서비스 레이어에서는 도메인 이벤트 중심(info)으로 로그가 남도록 정리했습니다.

<br>

## 🔁 변경 사항
### CompanyController
- 요청/성공 로그 추가 (조회 API는 debug, 변경 API는 info)

### CompanyServiceImpl
- 생성/수정/상태변경/삭제 성공 시 info 로그 추가 (companyId/hubId/name 등 주요 식별자 포함)
- 조회/검색은 debug 로그로 최소화

### CompanyValidator
- Hub/User 외부 호출 실패 시 error 로그 남기도록 처리

<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

