### PR TITLE
[fix] Swagger Request DTO 스키마 이름 충돌 오류 수정

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -22,29 +22,43 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
+    // Spring Boot Starter
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Spring Cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // External Libraries
     implementation 'com.github.ElevenHub:HubEleven-common:v0.0.1'
+
+    // API Documentation
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Database Driver
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // zipkin
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // Testing
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
@@ -1,5 +1,6 @@
 package com.hubEleven.order.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,15 +8,21 @@ import java.util.UUID;
 
 public class OrderRequests {
 
-	public record Create(
-			@NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
-			@NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
-			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-			@NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
-			@NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
-			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+    @Schema(name = "OrderCreateRequest", description = "주문 생성 요청")
+    public record Create(
+            @NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
+            @NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
+            @NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
+            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {
 
-	public record Update(
-			@Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
-			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
+    }
+
+    @Schema(name = "OrderUpdateRequest", description = "주문 수정 요청")
+    public record Update(
+            @Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
+            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {
+
+    }
 }

--- a/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
+++ b/order/src/main/java/com/hubEleven/order/presentation/dto/request/OrderRequests.java
@@ -8,21 +8,17 @@ import java.util.UUID;
 
 public class OrderRequests {
 
-    @Schema(name = "OrderCreateRequest", description = "주문 생성 요청")
-    public record Create(
-            @NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
-            @NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
-            @NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
-            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {
+	@Schema(name = "OrderCreateRequest", description = "주문 생성 요청")
+	public record Create(
+			@NotNull(message = "요청 업체 ID는 필수 입력 항목입니다.") UUID requestorCompanyId,
+			@NotNull(message = "수령 업체 ID는 필수 입력 항목입니다.") UUID recipientCompanyId,
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "배송 ID는 필수 입력 항목입니다.") UUID deliveryId,
+			@NotNull(message = "수량은 필수 입력 항목입니다.") Long quantity,
+			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
 
-    }
-
-    @Schema(name = "OrderUpdateRequest", description = "주문 수정 요청")
-    public record Update(
-            @Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
-            @Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {
-
-    }
+	@Schema(name = "OrderUpdateRequest", description = "주문 수정 요청")
+	public record Update(
+			@Min(value = 1, message = "수량은 1개 이상이어야 합니다.") Long quantity,
+			@Size(max = 500, message = "노트는 500자 이하여야 합니다.") String note) {}
 }

--- a/product/src/main/java/com/hubEleven/product/presentation/dto/request/ProductRequests.java
+++ b/product/src/main/java/com/hubEleven/product/presentation/dto/request/ProductRequests.java
@@ -8,19 +8,15 @@ import java.util.UUID;
 
 public class ProductRequests {
 
-    @Schema(name = "ProductCreateRequest", description = "상품 생성 요청")
-    public record Create(
-            @NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
-            String name,
-            @NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
-            @NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {
+	@Schema(name = "ProductCreateRequest", description = "상품 생성 요청")
+	public record Create(
+			@NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
+					String name,
+			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
+			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
 
-    }
-
-    @Schema(name = "ProductUpdateRequest", description = "상품 수정 요청")
-    public record Update(
-            @NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
-            String name) {
-
-    }
+	@Schema(name = "ProductUpdateRequest", description = "상품 수정 요청")
+	public record Update(
+			@NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
+					String name) {}
 }

--- a/product/src/main/java/com/hubEleven/product/presentation/dto/request/ProductRequests.java
+++ b/product/src/main/java/com/hubEleven/product/presentation/dto/request/ProductRequests.java
@@ -1,5 +1,6 @@
 package com.hubEleven.product.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,13 +8,19 @@ import java.util.UUID;
 
 public class ProductRequests {
 
-	public record Create(
-			@NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
-					String name,
-			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
-			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
+    @Schema(name = "ProductCreateRequest", description = "상품 생성 요청")
+    public record Create(
+            @NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
+            String name,
+            @NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
+            @NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {
 
-	public record Update(
-			@NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
-					String name) {}
+    }
+
+    @Schema(name = "ProductUpdateRequest", description = "상품 수정 요청")
+    public record Update(
+            @NotBlank(message = "상품명은 필수 입력 항목입니다.") @Size(max = 150, message = "상품명은 150자 이하여야 합니다.")
+            String name) {
+
+    }
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -7,32 +7,24 @@ import java.util.UUID;
 
 public class StockRequests {
 
-    @Schema(name = "StockCreateRequest", description = "재고 생성 요청")
-    public record Create(
-            @NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
-            int quantity,
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
-            @NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {
+	@Schema(name = "StockCreateRequest", description = "재고 생성 요청")
+	public record Create(
+			@NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+					int quantity,
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
+			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
 
-    }
+	@Schema(name = "StockUpdateRequest", description = "재고 수정 요청")
+	public record Update(@Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {}
 
-    @Schema(name = "StockUpdateRequest", description = "재고 수정 요청")
-    public record Update(@Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {
+	public record Restore(
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
+					int quantity) {}
 
-    }
-
-    public record Restore(
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
-            int quantity) {
-
-    }
-
-    public record Decrease(
-            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-            @NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
-            int quantity) {
-
-    }
+	public record Decrease(
+			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+			@NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+					int quantity) {}
 }

--- a/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
+++ b/product/src/main/java/com/hubEleven/stock/presentation/dto/request/StockRequests.java
@@ -1,27 +1,38 @@
 package com.hubEleven.stock.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class StockRequests {
 
-	public record Create(
-			@NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
-					int quantity,
-			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-			@NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
-			@NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {}
+    @Schema(name = "StockCreateRequest", description = "재고 생성 요청")
+    public record Create(
+            @NotNull(message = "수량은 필수 입력 항목입니다.") @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+            int quantity,
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "업체 ID는 필수 입력 항목입니다.") UUID companyId,
+            @NotNull(message = "허브 ID는 필수 입력 항목입니다.") UUID hubId) {
 
-	public record Update(@Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {}
+    }
 
-	public record Restore(
-			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-			@NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
-					int quantity) {}
+    @Schema(name = "StockUpdateRequest", description = "재고 수정 요청")
+    public record Update(@Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {
 
-	public record Decrease(
-			@NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
-			@NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
-					int quantity) {}
+    }
+
+    public record Restore(
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "취소 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "취소 수량은 1 이상이어야 합니다.")
+            int quantity) {
+
+    }
+
+    public record Decrease(
+            @NotNull(message = "상품 ID는 필수 입력 항목입니다.") UUID productId,
+            @NotNull(message = "주문 수량은 필수 입력 항목입니다.") @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+            int quantity) {
+
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #136 

<br>

## 📌 개요
- Spring Boot + springdoc-openapi 환경에서 Swagger UI에서 사용하는 Request DTO들의 스키마 이름이 충돌하여, 서로 다른 DTO임에도 하나의 Create 스키마로 문서화되던 문제를 해결했습니다.

<br>

## 🔁 변경 사항
- ProductRequests.Create, StockRequests.Create 등 동일한 단순 클래스 이름을 가진 record DTO에 @Schema를 적용해, Swagger 문서에서 각각 독립된 스키마 이름을 사용하도록 수정했습니다.
​
<br>

## 📸 스크린샷

<details>
  <summary>제목</summary>
  스크린샷
</details>

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

