### PR TITLE
[fix] Slack 메시지 생성 시 주문/배송 정보가 Slack 본문에 반영되지 않는 문제

### DIFF
--- a/notification/src/main/java/com/hubEleven/notification/slack/application/service/impl/SlackServiceImpl.java
+++ b/notification/src/main/java/com/hubEleven/notification/slack/application/service/impl/SlackServiceImpl.java
@@ -4,6 +4,7 @@ import com.commonLib.common.exception.GlobalException;
 import com.commonLib.common.request.CommonPageRequest;
 import com.commonLib.common.response.CommonPageResponse;
 import com.commonLib.common.utils.PagingUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubEleven.notification.ai.domain.repository.AiRequestLogRepository;
 import com.hubEleven.notification.ai.exception.AiErrorCode;
@@ -20,7 +21,6 @@ import com.hubEleven.notification.slack.domain.service.SlackDomainService;
 import com.hubEleven.notification.slack.domain.vo.SlackMessageContext;
 import com.hubEleven.notification.slack.domain.vo.SlackMessageItem;
 import com.hubEleven.notification.slack.exception.SlackErrorCode;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -48,15 +48,19 @@ public class SlackServiceImpl implements SlackService {
 	public SlackMessageResult createMessage(CreateSlackMessageCommand command) {
 		slackValidator.slackCreate(command.orderId());
 
-		ResponsePayload payload = findAiPayloadOrThrow(command.orderId());
+		SlackMessageContext context = buildSlackMessageContext(command);
 
-		SlackMessageContext context = buildSlackMessageContext(command.orderId(), payload);
+		AiPayload aiPayload = findAiPayloadOrThrow(command.orderId());
 
-		String formattedMessage = slackDomainService.formatMessage(context, payload.messageBody);
+		String formattedMessage = slackDomainService.formatMessage(context, aiPayload.messageBody());
 
 		SlackMessage slackMessage =
 				SlackMessage.create(
-						command.orderId(), command.recipientId(), command.channel(), formattedMessage);
+						command.orderId(),
+						command.recipientId(),
+						command.channel(),
+						formattedMessage
+				);
 
 		SlackMessage saved = slackMessageRepository.save(slackMessage);
 
@@ -124,29 +128,39 @@ public class SlackServiceImpl implements SlackService {
 				SlackMessageResult::from);
 	}
 
-	private ResponsePayload findAiPayloadOrThrow(UUID orderId) {
+	private AiPayload findAiPayloadOrThrow(UUID orderId) {
 		return aiRequestLogRepository
 				.findByOrderId(orderId)
-				.map(
-						logEntry -> {
-							String raw = logEntry.getRawResponse();
-							String cleaned = cleanJsonResponse(raw);
+				.map(logEntry -> {
+					String messageBody = logEntry.getMessageBody();
+					String finalDeadline = logEntry.getFinalDispatchDeadline();
 
-							try {
-								ResponsePayload payload = objectMapper.readValue(cleaned, ResponsePayload.class);
+					if (messageBody != null && !messageBody.isBlank()) {
+						return new AiPayload(finalDeadline, messageBody);
+					}
 
-								if (payload.finalDispatchDeadline == null
-										|| payload.finalDispatchDeadline.isBlank()) {
-									throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-								}
-								if (payload.messageBody == null || payload.messageBody.isBlank()) {
-									throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-								}
-								return payload;
-							} catch (Exception e) {
-								throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-							}
-						})
+					String raw = logEntry.getRawResponse();
+					if (raw == null || raw.isBlank()) {
+						throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+					}
+
+					String cleaned = cleanJsonResponse(raw);
+
+					try {
+						JsonNode node = objectMapper.readTree(cleaned);
+
+						String parsedDeadline = node.path("finalDispatchDeadline").asText(null);
+						String parsedBody = node.path("messageBody").asText(null);
+
+						if (parsedBody == null || parsedBody.isBlank()) {
+							throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+						}
+
+						return new AiPayload(parsedDeadline, parsedBody);
+					} catch (Exception e) {
+						throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+					}
+				})
 				.orElseThrow(() -> new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL));
 	}
 
@@ -170,45 +184,32 @@ public class SlackServiceImpl implements SlackService {
 		return cleaned.trim();
 	}
 
-	private SlackMessageContext buildSlackMessageContext(UUID orderId, ResponsePayload payload) {
-		LocalDateTime orderDateTime = parseLocalDateTime(payload.orderDateTime);
-
-		List<String> viaHubs = (payload.viaHubs == null) ? Collections.emptyList() : payload.viaHubs;
+	private SlackMessageContext buildSlackMessageContext(CreateSlackMessageCommand cmd) {
+		List<String> viaHubs = (cmd.viaHubs() == null) ? Collections.emptyList() : cmd.viaHubs();
 
 		List<SlackMessageItem> items =
-				(payload.items == null)
+				(cmd.items() == null)
 						? Collections.emptyList()
-						: payload.items.stream()
-								.map(
-										it ->
-												new SlackMessageItem(
-														nullToEmpty(it.name), it.quantity, nullToEmpty(it.note)))
-								.toList();
+						: cmd.items().stream()
+						.map(it -> new SlackMessageItem(
+								nullToEmpty(it.name()),
+								it.quantity(),
+								nullToEmpty(it.note())))
+						.toList();
 
 		return new SlackMessageContext(
-				orderId,
-				blankToNull(payload.customerName),
-				blankToNull(payload.customerEmail),
-				orderDateTime,
-				blankToNull(payload.sourceHub),
+				cmd.orderId(),
+				blankToNull(cmd.customerName()),
+				blankToNull(cmd.customerEmail()),
+				cmd.orderDateTime(),
+				blankToNull(cmd.sourceHub()),
 				viaHubs,
-				blankToNull(payload.destinationHub),
-				blankToNull(payload.destinationAddress),
-				blankToNull(payload.requestNote),
-				blankToNull(payload.deliveryManagerName),
-				blankToNull(payload.deliveryManagerEmail),
+				blankToNull(cmd.destinationHub()),
+				blankToNull(cmd.destinationAddress()),
+				blankToNull(cmd.requestNote()),
+				blankToNull(cmd.deliveryManagerName()),
+				blankToNull(cmd.deliveryManagerEmail()),
 				items);
-	}
-
-	private LocalDateTime parseLocalDateTime(String value) {
-		if (value == null || value.isBlank()) {
-			return null;
-		}
-		try {
-			return LocalDateTime.parse(value.trim());
-		} catch (Exception ignore) {
-			return null;
-		}
 	}
 
 	private String blankToNull(String s) {
@@ -219,26 +220,5 @@ public class SlackServiceImpl implements SlackService {
 		return (s == null) ? "" : s;
 	}
 
-	private static final class ResponsePayload {
-		public String finalDispatchDeadline;
-		public String messageBody;
-
-		public String customerName;
-		public String customerEmail;
-		public String orderDateTime;
-		public String sourceHub;
-		public List<String> viaHubs;
-		public String destinationHub;
-		public String destinationAddress;
-		public String requestNote;
-		public String deliveryManagerName;
-		public String deliveryManagerEmail;
-		public List<ItemPayload> items;
-	}
-
-	private static final class ItemPayload {
-		public String name;
-		public int quantity;
-		public String note;
-	}
+	private record AiPayload(String finalDispatchDeadline, String messageBody) {}
 }

--- a/notification/src/main/java/com/hubEleven/notification/slack/application/service/impl/SlackServiceImpl.java
+++ b/notification/src/main/java/com/hubEleven/notification/slack/application/service/impl/SlackServiceImpl.java
@@ -56,11 +56,7 @@ public class SlackServiceImpl implements SlackService {
 
 		SlackMessage slackMessage =
 				SlackMessage.create(
-						command.orderId(),
-						command.recipientId(),
-						command.channel(),
-						formattedMessage
-				);
+						command.orderId(), command.recipientId(), command.channel(), formattedMessage);
 
 		SlackMessage saved = slackMessageRepository.save(slackMessage);
 
@@ -131,36 +127,37 @@ public class SlackServiceImpl implements SlackService {
 	private AiPayload findAiPayloadOrThrow(UUID orderId) {
 		return aiRequestLogRepository
 				.findByOrderId(orderId)
-				.map(logEntry -> {
-					String messageBody = logEntry.getMessageBody();
-					String finalDeadline = logEntry.getFinalDispatchDeadline();
+				.map(
+						logEntry -> {
+							String messageBody = logEntry.getMessageBody();
+							String finalDeadline = logEntry.getFinalDispatchDeadline();
 
-					if (messageBody != null && !messageBody.isBlank()) {
-						return new AiPayload(finalDeadline, messageBody);
-					}
+							if (messageBody != null && !messageBody.isBlank()) {
+								return new AiPayload(finalDeadline, messageBody);
+							}
 
-					String raw = logEntry.getRawResponse();
-					if (raw == null || raw.isBlank()) {
-						throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-					}
+							String raw = logEntry.getRawResponse();
+							if (raw == null || raw.isBlank()) {
+								throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+							}
 
-					String cleaned = cleanJsonResponse(raw);
+							String cleaned = cleanJsonResponse(raw);
 
-					try {
-						JsonNode node = objectMapper.readTree(cleaned);
+							try {
+								JsonNode node = objectMapper.readTree(cleaned);
 
-						String parsedDeadline = node.path("finalDispatchDeadline").asText(null);
-						String parsedBody = node.path("messageBody").asText(null);
+								String parsedDeadline = node.path("finalDispatchDeadline").asText(null);
+								String parsedBody = node.path("messageBody").asText(null);
 
-						if (parsedBody == null || parsedBody.isBlank()) {
-							throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-						}
+								if (parsedBody == null || parsedBody.isBlank()) {
+									throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+								}
 
-						return new AiPayload(parsedDeadline, parsedBody);
-					} catch (Exception e) {
-						throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
-					}
-				})
+								return new AiPayload(parsedDeadline, parsedBody);
+							} catch (Exception e) {
+								throw new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL);
+							}
+						})
 				.orElseThrow(() -> new GlobalException(AiErrorCode.AI_RESPONSE_PARSE_FAIL));
 	}
 
@@ -191,11 +188,11 @@ public class SlackServiceImpl implements SlackService {
 				(cmd.items() == null)
 						? Collections.emptyList()
 						: cmd.items().stream()
-						.map(it -> new SlackMessageItem(
-								nullToEmpty(it.name()),
-								it.quantity(),
-								nullToEmpty(it.note())))
-						.toList();
+								.map(
+										it ->
+												new SlackMessageItem(
+														nullToEmpty(it.name()), it.quantity(), nullToEmpty(it.note())))
+								.toList();
 
 		return new SlackMessageContext(
 				cmd.orderId(),

--- a/notification/src/main/java/com/hubEleven/notification/slack/domain/event/handler/SlackDomainEventHandler.java
+++ b/notification/src/main/java/com/hubEleven/notification/slack/domain/event/handler/SlackDomainEventHandler.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -23,6 +25,7 @@ public class SlackDomainEventHandler {
 	private final SlackClient slackClient;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handle(SlackMessageSavedEvent event) {
 		UUID messageId = event.messageId();
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #138 

<br>

## 📌 개요
- Slack 메시지 생성 API는 성공 응답을 반환하지만, 실제 Slack 전송 결과가 DB에 반영되지 않아 status=PENDING, sent_at=NULL 상태로 남는 문제를 수정했습니다.

<br>

## 🔁 변경 사항
Slack 전송 후 상태 업데이트
- SlackDomainEventHandler에서 Slack 전송 성공 시 status=SENT, sent_at=now() 저장
- 전송 실패 시 status=FAILED 저장 (에러 로그 포함)
- 이벤트 처리 저장을 REQUIRES_NEW로 분리하여 상태 반영 안정화

Slack 메시지 구성 로직 개선

- SlackServiceImpl에서 SlackMessageContext를 CreateSlackMessageCommand 기반으로 생성
- AI 결과는 AiRequestLog.messageBody(또는 rawResponse fallback)만 사용하여 Slack 메시지 하단에 붙이는 방식으로 변경
- 결과적으로 Slack 메시지 상단 요약 정보가 요청 데이터 기준으로 정상 표기되도록 수정
<br>

## 📸 스크린샷

<img width="1224" height="778" alt="image" src="https://github.com/user-attachments/assets/19befae6-7bb3-4010-b523-f2331b5d85c7" />

<br>

## 👀 기타 더 이야기해볼 점

<br>

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

